### PR TITLE
GH01: Graceful Max-Iteration Exhaustion

### DIFF
--- a/docs/projects/1/design.md
+++ b/docs/projects/1/design.md
@@ -1,0 +1,66 @@
+# #1 — Graceful Max-Iteration Exhaustion
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/1
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+When `maxToolRounds` is hit, the for-loop in `_chatImpl` exits silently. The text extraction logic at the end grabs whatever was in the last assistant message — often a `tool_use` block with no text, or mid-thought content.
+
+## Design
+
+### Flag-based detection
+
+Add a `let exitedNormally = false` flag before the for-loop. Set it `true` inside the `end_turn`/`max_tokens` break (line ~183). After the for-loop, check the flag.
+
+### Forced final response
+
+If `!exitedNormally`:
+
+1. Push a system nudge as a user message:
+   ```
+   history.push({ role: 'user', content: '[System: Max tool calls reached. Provide final response now.]' });
+   ```
+
+2. Make one final model call with **no tools**:
+   ```
+   const finalResponse = await deps.model.complete({
+     system: systemPrompt,
+     messages: history,
+     tools: [],          // forces text-only response
+     model: deps.config.model,
+     max_tokens: deps.config.maxTokens,
+     temperature: deps.config.temperature,
+     timeout: deps.config.modelTimeout,
+   });
+   ```
+
+3. Accumulate usage stats:
+   ```
+   rounds++;
+   totalInputTokens += finalResponse.usage.input_tokens;
+   totalOutputTokens += finalResponse.usage.output_tokens;
+   ```
+
+4. Push final assistant response to history:
+   ```
+   history.push({ role: 'assistant', content: finalResponse.content });
+   ```
+
+5. Existing text extraction logic at the end of `_chatImpl` handles the rest — it finds the last assistant message and extracts text blocks.
+
+### Why `tools: []` works
+
+With no tools in the request, the model cannot return `tool_use` blocks. It must produce text. This guarantees a coherent wrap-up response.
+
+## Files Touched
+
+- `src/agent/agent.ts` — ~20 lines after the for-loop
+
+## Acceptance Criteria
+
+1. When maxToolRounds exhausted, a system nudge message appears in history
+2. A final model call with `tools: []` produces a text response
+3. Usage stats from the final call are included in `ChatStats`
+4. `rounds` count includes the final call
+5. Test: mock model that always returns `tool_use` → verify final forced text response after maxToolRounds

--- a/docs/projects/1/implementation-plan/phase_01.md
+++ b/docs/projects/1/implementation-plan/phase_01.md
@@ -1,0 +1,204 @@
+# GH01: Graceful Max-Iteration Exhaustion — Implementation Plan
+
+**Goal:** When the agent's tool loop exhausts `maxToolRounds`, produce a coherent text response instead of silently returning whatever was in the last (likely incomplete) assistant message.
+
+**Architecture:** Add an `exitedNormally` flag to the existing `for` loop in `_chatImpl`. When the loop exits without an `end_turn`/`max_tokens` break, push a system nudge and make one final model call with `tools: []` to force a text-only wrap-up.
+
+**Tech Stack:** TypeScript, Bun test runner (`bun:test`)
+
+**Scope:** 1 phase (complete feature)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH01.AC1: System nudge on exhaustion
+- **GH01.AC1.1 Success:** When maxToolRounds exhausted, a system nudge message appears in history
+
+### GH01.AC2: Forced text-only final call
+- **GH01.AC2.1 Success:** A final model call with `tools: []` produces a text response
+- **GH01.AC2.2 Success:** Usage stats from the final call are included in `ChatStats`
+- **GH01.AC2.3 Success:** `rounds` count includes the final call
+
+### GH01.AC3: Normal exit unaffected
+- **GH01.AC3.1 Success:** When the loop exits via `end_turn` or `max_tokens`, no nudge is injected and no extra model call is made
+
+### GH01.AC4: Integration test
+- **GH01.AC4.1 Success:** Mock model that always returns `tool_use` produces a final forced text response after maxToolRounds
+
+---
+
+## Phase 1: Flag-Based Exhaustion Detection and Forced Final Response
+
+This is a functionality phase. All changes are in `src/agent/agent.ts` with a new test file at `src/agent/agent.test.ts`.
+
+<!-- START_SUBCOMPONENT_A (tasks 1-4) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `exitedNormally` flag and forced final response logic
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1
+
+**Files:**
+- Modify: `src/agent/agent.ts:147-233` (the tool loop and the code immediately after it)
+
+**Implementation:**
+
+Before the `for` loop at line 148, add:
+
+```typescript
+let exitedNormally = false;
+```
+
+Inside the `end_turn`/`max_tokens` break at line 181-184, set the flag before breaking:
+
+```typescript
+if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
+  process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+  exitedNormally = true;
+  break;
+}
+```
+
+After the closing `}` of the `for` loop (line 233) and before the `// f. Extract final text` comment (line 235), insert the forced final response block:
+
+```typescript
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
+    }
+```
+
+**Key details:**
+- `tools: []` prevents the model from returning `tool_use` blocks — it must produce text.
+- The nudge is a plain string user message, not an array of content blocks. This matches how the agent already pushes user messages (line 121).
+- Usage stats are accumulated into the existing `totalInputTokens`/`totalOutputTokens`/`rounds` variables. The final `ChatStats` object at line 246 already reads from these, so no further changes needed.
+- The existing text extraction logic at line 235-263 handles the rest — it finds the last assistant message and extracts text blocks. Since the forced response is the last assistant message and contains only text blocks (no `tool_use` possible), it works as-is.
+
+**Verification:**
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+**Commit:** `feat(agent): add exitedNormally flag and forced final response on max-iteration exhaustion`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Write tests for max-iteration exhaustion
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1, GH01.AC4.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Context for test construction:**
+
+The `createAgent` function (exported from `src/agent/agent.ts`) takes an `AgentDependencies` object. The key deps to mock are:
+
+1. **`model: ModelProvider`** — needs a `complete()` method returning `ModelResponse`. The mock controls `stop_reason` and `content` to simulate tool_use vs end_turn behaviour.
+
+2. **`runtime: CodeRuntime`** — needs an `execute()` method returning `ExecutionResult`. For these tests, the runtime mock just returns a success result since we're testing loop exit behaviour, not tool execution.
+
+3. **`store: Store`** — the agent calls `store.docGet('self')` and `store.docList(500)` during prompt building. Mock these to return minimal data.
+
+4. **`config: AgentConfig`** — set `maxToolRounds` to a small number (e.g., 2 or 3) to trigger exhaustion quickly.
+
+5. **`personaPath: string`** — points to a file read with `Bun.file().text()`. Create a temp file or use an existing fixture.
+
+The agent also writes to `src/runtime/deno/tools.ts` via `Bun.write`. Ensure the directory exists or mock accordingly.
+
+**Testing:**
+
+Tests must verify each AC listed above:
+
+- **GH01.AC1.1:** After the model returns `tool_use` for every round up to `maxToolRounds`, assert that history contains a user message with content `'[System: Max tool calls reached. Provide final response now.]'`.
+
+- **GH01.AC2.1:** Assert the mock model's `complete` was called one final time after the loop with `tools: []` in the request, and the returned `ChatResult.text` contains the forced response text.
+
+- **GH01.AC2.2:** Assert `ChatResult.stats.inputTokens` and `stats.outputTokens` include the usage from the final forced call (sum of all rounds including the forced one).
+
+- **GH01.AC2.3:** Assert `ChatResult.stats.rounds` equals `maxToolRounds + 1` (the loop rounds plus the forced final call).
+
+- **GH01.AC3.1:** When the model returns `end_turn` on the first call, assert no nudge message in history, `stats.rounds` equals 1, and `complete` was called exactly once.
+
+- **GH01.AC4.1:** End-to-end mock scenario: model always returns `tool_use` except when called with `tools: []` (then returns text). Verify the agent returns the forced text response and all stats are correct.
+
+**Mock strategy:**
+
+The model mock should track call count and inspect the `tools` parameter:
+- When `tools` contains `EXECUTE_CODE_TOOL`: return a `tool_use` response with a dummy tool call
+- When `tools` is `[]`: return an `end_turn` response with a text block containing known text (e.g., `"Forced wrap-up response"`)
+
+The runtime mock returns `{ success: true, output: 'ok', error: null, duration_ms: 0 }` for all executions.
+
+The store mock returns `null` for `docGet` and `{ documents: [], total: 0 }` for `docList`.
+
+Create a temp persona file using `Bun.write` in a `beforeAll` block pointing to a temp directory (`import { mkdtemp } from 'node:fs/promises'`), containing minimal persona text.
+
+**Verification:**
+Run: `bun test`
+Expected: All tests pass
+
+**Commit:** `test(agent): add tests for graceful max-iteration exhaustion`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Run full verification
+
+**Files:** None (verification only)
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+Run: `bun test`
+Expected: All tests pass
+
+Run: `bun run build && bun test`
+Expected: Both succeed
+
+This task has no commit — it's a verification gate.
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Final commit
+
+**Files:** None (commit only — all changes from Tasks 1-2 should already be committed)
+
+**Verification:**
+
+Run: `git status`
+Expected: Working tree clean, all changes committed
+
+Run: `git log --oneline -3`
+Expected: Two commits visible — implementation and tests
+
+This task exists to ensure everything is committed and the branch is clean.
+<!-- END_TASK_4 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/1/implementation-plan/test-requirements.md
+++ b/docs/projects/1/implementation-plan/test-requirements.md
@@ -1,0 +1,18 @@
+# GH01: Graceful Max-Iteration Exhaustion — Test Requirements
+
+Maps each acceptance criterion to automated tests. All tests are unit tests in `src/agent/agent.test.ts` using `bun:test`.
+
+## Automated Tests
+
+| AC ID | Criterion | Test Type | Test File | Test Description |
+|-------|-----------|-----------|-----------|------------------|
+| GH01.AC1.1 | System nudge appears in history on exhaustion | unit | `src/agent/agent.test.ts` | After model returns `tool_use` for all `maxToolRounds`, inspect history for user message containing `'[System: Max tool calls reached. Provide final response now.]'` |
+| GH01.AC2.1 | Final call with `tools: []` produces text | unit | `src/agent/agent.test.ts` | Mock model returns text when `tools` is `[]`. Assert `ChatResult.text` matches the forced response text. Assert model was called with `tools: []` on the final call. |
+| GH01.AC2.2 | Final call usage stats included in ChatStats | unit | `src/agent/agent.test.ts` | Mock model returns known usage values per call. Assert `stats.inputTokens` and `stats.outputTokens` equal the sum across all calls including the forced one. |
+| GH01.AC2.3 | Rounds count includes final call | unit | `src/agent/agent.test.ts` | With `maxToolRounds: N`, assert `stats.rounds` equals `N + 1` when exhaustion occurs. |
+| GH01.AC3.1 | Normal exit unaffected | unit | `src/agent/agent.test.ts` | Model returns `end_turn` immediately. Assert no nudge in history, `stats.rounds` equals 1, model called exactly once. |
+| GH01.AC4.1 | Integration: always-tool_use model forced to text | unit | `src/agent/agent.test.ts` | End-to-end scenario: model returns `tool_use` until `tools: []`, then returns text. Verify returned text, correct round count, correct token sums. |
+
+## Human Verification
+
+None required. All acceptance criteria are testable via automated unit tests with mocked dependencies.

--- a/docs/projects/feature-parity-dag.md
+++ b/docs/projects/feature-parity-dag.md
@@ -1,0 +1,386 @@
+# Feature Parity — Build Order DAG
+
+This document defines the dependency graph and implementation steps for all 14 feature-parity issues. Features are grouped into waves that can execute in parallel. Within each wave, independent features can be built by separate agents simultaneously.
+
+## Dependency Graph
+
+```
+Wave 0 (foundations — no dependencies)
+├── #14 Standalone Secrets Management
+├── #11 Extended Thinking / Reasoning Content Preservation
+└── #1  Graceful Max-Iteration Exhaustion
+
+Wave 1 (depends on Wave 0)
+├── #4  Sub-Agent LLM                          (depends on: #14 for secret resolution)
+├── #2  Event Emission / Lifecycle Hooks        (no hard deps, but Wave 0 clears the agent loop)
+├── #12 Dynamic System Prompt Provider          (no hard deps, touches agent loop)
+└── #3  Multi-Tool Architecture                 (no hard deps, major registry refactor)
+
+Wave 2 (depends on Wave 1)
+├── #7  Built-In Web Tools                      (depends on: #3 native tools, #14 secrets)
+├── #6  Outbound Notification Tool              (depends on: #3 native tools, #14 secrets)
+├── #9  Image Viewing Tool                      (depends on: #3 native tools + content block support)
+├── #8  Summarization Tool                      (depends on: #3 native tools, #4 sub-agent)
+└── #5  Auto-Generated Session Titles           (depends on: #4 sub-agent)
+
+Wave 3 (depends on Wave 2)
+├── #10 Custom Tool Creation + Approval         (depends on: #3 multi-tool, #14 secrets)
+└── #13 Multi-Screen TUI                        (depends on: #2 events, #5 titles, #14 secrets, #10 custom tools)
+```
+
+## Edge List (for tooling)
+
+```
+#4  → #14
+#7  → #3, #14
+#6  → #3, #14
+#9  → #3
+#8  → #3, #4
+#5  → #4
+#10 → #3, #14
+#13 → #2, #5, #10, #14
+```
+
+---
+
+## Wave 0 — Foundations
+
+### #14 Standalone Secrets Management
+
+**Status:** Mostly done. `src/secrets/manager.ts` already implements the full `SecretManager` interface (listKeys, get, set, remove, resolve). Stored at `data/secrets.json`.
+
+**Remaining work:**
+1. Verify the existing `SecretManager` type is exported and usable by new consumers (web tools, notification tool, custom tools)
+2. Add `save()` returning a `Promise<void>` that callers can await (currently fire-and-forget)
+3. Add integration test: create manager, set/get/remove/resolve secrets, verify JSON file on disk
+4. No TUI work yet — that's #13
+
+**Files touched:** `src/secrets/manager.ts`, `src/secrets/index.ts`, new test file
+
+---
+
+### #11 Extended Thinking / Reasoning Content Preservation
+
+**Steps:**
+1. Add `ReasoningBlock` to model types: `{ type: 'thinking'; thinking: string }` in `src/model/types.ts`
+2. Add `reasoning_content?: string` field to `ModelResponse` in `src/model/types.ts`
+3. Update each model provider to extract reasoning content from API responses:
+   - `src/model/anthropic.ts` — extract from `thinking` content blocks
+   - `src/model/openrouter.ts` — extract from response metadata / reasoning field
+   - `src/model/openai-compat.ts` — extract if present (o1-style reasoning)
+   - `src/model/ollama.ts` — no-op (local models don't emit reasoning)
+4. In `src/agent/agent.ts`, after building `assistantMessage`, attach `reasoning_content` if present — store it on the message object (extend `Message` type or use a side map)
+5. Update `src/agent/compaction.ts` `formatConversation()` to include reasoning content when serializing for compaction
+6. Add test: mock model response with reasoning → verify it's stored on the assistant message in history
+
+**Files touched:** `src/model/types.ts`, `src/model/anthropic.ts`, `src/model/openrouter.ts`, `src/model/openai-compat.ts`, `src/agent/agent.ts`, `src/agent/compaction.ts`
+
+---
+
+### #1 Graceful Max-Iteration Exhaustion
+
+**Steps:**
+1. In `src/agent/agent.ts`, after the `for` loop (line ~233), detect whether the loop exited because `round === maxToolRounds` (vs. `end_turn`/`max_tokens`)
+2. If exhausted: push a system-style user message `[System: Max tool calls reached. Provide final response now.]` to history
+3. Make one final `deps.model.complete()` call with `tools: []` (no tools available)
+4. Accumulate usage stats from this final call into `totalInputTokens`, `totalOutputTokens`, increment `rounds`
+5. Push the final assistant response to history
+6. Existing text extraction logic at line ~236 handles the rest
+7. Add test: mock model that always returns `tool_use` → verify final forced response after maxToolRounds
+
+**Files touched:** `src/agent/agent.ts`
+
+**Implementation detail:** Track a `let exitedNormally = false` flag. Set it true inside the `end_turn`/`max_tokens` break. After the for-loop, check `if (!exitedNormally)`.
+
+---
+
+## Wave 1 — Core Infrastructure
+
+### #4 Sub-Agent LLM
+
+**Steps:**
+1. Add sub-model config types to `src/config/types.ts`:
+   ```
+   SubModelConfig {
+     provider: 'anthropic' | 'openai-compat';
+     name: string;
+     maxTokens: number;     // default 8000
+     baseUrl?: string;
+     apiKey?: string;
+   }
+   ```
+   Add `subModel?: SubModelConfig` to `AppConfig`.
+2. Add TOML keys `[sub_model]` to `src/config/loader.ts` with env overrides (`SUB_MODEL_NAME`, `SUB_MODEL_API_KEY`, etc.)
+3. Create `src/model/sub-agent.ts` — a lightweight wrapper:
+   - Takes `SubModelConfig`
+   - Implements a simple `complete(prompt: string, system?: string): Promise<string>` (text in, text out — not `ModelProvider`)
+   - Uses Anthropic SDK or fetch-based OpenAI-compat call
+   - Falls back to the main `ModelProvider` if sub-model not configured
+4. Export a `SubAgentLLM` type from `src/model/sub-agent.ts`
+5. Wire up in `src/index.ts`: create `SubAgentLLM` from config, pass into `AgentDependencies`
+6. Add `subAgent?: SubAgentLLM` to `AgentDependencies` in `src/agent/types.ts`
+7. Update compaction (`src/agent/compaction.ts`) to prefer sub-agent for summarization when available
+8. Add test: sub-agent with mocked provider returns expected text
+
+**Files touched:** `src/config/types.ts`, `src/config/loader.ts`, `src/model/sub-agent.ts` (new), `src/agent/types.ts`, `src/agent/compaction.ts`, `src/index.ts`
+
+---
+
+### #2 Event Emission / Lifecycle Hooks
+
+**Steps:**
+1. Define event types in `src/agent/types.ts`:
+   ```
+   type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+   type AgentEvent = { kind: AgentEventKind; data: Record<string, unknown> };
+   ```
+2. Add `onEvent?: (event: AgentEvent) => Promise<void>` to `ChatOptions`
+3. In `src/agent/agent.ts`, create a helper `const emit = async (kind, data) => { if (options?.onEvent) await options.onEvent({ kind, data }); };`
+4. Emit events at four points in the tool loop:
+   - Before `deps.model.complete()`: `emit('llm_start', { round })`
+   - After `deps.model.complete()`: `emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason })`
+   - Before `deps.runtime.execute()`: `emit('tool_start', { tool: 'execute_code', code: code.slice(0, 500) })`
+   - After `deps.runtime.execute()`: `emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) })`
+5. Add test: provide onEvent callback, run chat with tool use, verify all four event kinds fired in order
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`
+
+---
+
+### #12 Dynamic System Prompt Provider
+
+**Steps:**
+1. Add `systemPromptProvider?: () => Promise<string>` to `AgentDependencies` in `src/agent/types.ts`
+2. In `src/agent/agent.ts` `_chatImpl`, before the existing prompt-building block (lines 96-106), check for `deps.systemPromptProvider`:
+   - If present: call it, catch errors and log + fall back to previous cached prompt
+   - If absent: use existing `buildSystemPrompt()` logic (no change)
+3. Store last-good prompt in a closure variable `let cachedSystemPrompt = ''`
+4. Wire up in `src/index.ts`: create a provider function that calls `buildSystemPrompt()` with fresh data from store (self doc, skills, tool docs, secrets list)
+5. This makes the existing prompt-building logic the *default provider* — same behavior, now hookable
+6. Add test: provider that throws → verify fallback to cached prompt
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`, `src/index.ts`
+
+---
+
+### #3 Multi-Tool Architecture
+
+**REVISED:** Keep `execute_code` as primary dispatch. Native tool_use only for tools where the result format demands it (images) or sandbox adds no value (notify, summarize). Existing 8 tools stay sandbox-only. See `docs/projects/3/design.md` for full rationale.
+
+**Steps:**
+1. **Extend ToolRegistry** (`src/runtime/tool-registry.ts`):
+   - Add `mode: 'sandbox' | 'native' | 'both'` per tool entry
+   - Add `generateToolDefinitions(): ToolDefinition[]` — returns definitions for native/both-mode tools only
+   - Existing `generateTypeScriptStubs()` generates stubs for sandbox/both-mode tools only
+   - Existing `generateToolDocumentation()` documents ALL tools regardless of mode
+
+2. **Update agent loop** (`src/agent/agent.ts`):
+   - Build tool list: `[EXECUTE_CODE_TOOL, ...registry.generateToolDefinitions()]`
+   - When dispatching `tool_use` blocks, check tool name:
+     - If `execute_code`: existing Deno sandbox path (unchanged)
+     - If any other registered tool: call `registry.execute(name, input)` directly
+   - Add `formatNativeToolResult()` helper for image content block support
+
+3. **Update model types** (`src/model/types.ts`):
+   - Widen `ToolResultBlock.content` to `string | Array<ContentBlock>`
+
+4. **Existing tools unchanged** — all 8 remain `mode: 'sandbox'`
+
+5. **Native tools (added by later features):**
+   - `view_image` (#9) — `mode: 'native'` (image content blocks)
+   - `notify_discord` (#6) — `mode: 'both'` (native + sandbox for scheduled tasks)
+   - `summarize` (#8) — `mode: 'both'` (native + sandbox for composition)
+
+**Files touched:** `src/runtime/tool-registry.ts`, `src/agent/agent.ts`, `src/model/types.ts`
+
+---
+
+## Wave 2 — Tools and Features
+
+### #7 Built-In Web Tools
+
+**Steps:**
+1. Create `src/tools/web.ts` with three tool definitions:
+   - `web_search` — calls Exa search API (`api.exa.ai/search`)
+   - `fetch_page` — calls Exa contents API (`api.exa.ai/contents`)
+   - `http_get` — plain `fetch()` GET request
+2. Each returns structured JSON results (title, url, snippet, score for search; text + metadata for fetch)
+3. Register all three in `src/agent/tools.ts` via `createAgentTools()` — conditionally based on Exa API key availability
+4. Exa API key resolution: check `deps.secrets?.get('EXA_API_KEY')` then fall back to `process.env.EXA_API_KEY`
+5. `http_get` always available (no API key needed). `web_search` and `fetch_page` return clear error if no Exa key
+6. Add `mode: 'native'` so these are exposed as direct tool_use definitions
+7. Truncation: `max_chars` param (default 10000, cap 50000) for `fetch_page` and `http_get`
+8. Add tests: mock fetch responses, verify structured output
+
+**Files touched:** `src/tools/web.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #6 Outbound Notification Tool (Discord Webhook)
+
+**Steps:**
+1. Create `src/tools/notify.ts` with `notify_discord` tool definition
+2. Parameters: `content` (required string), `title` (optional string)
+3. Implementation:
+   - Get webhook URL from `deps.secrets?.get('DISCORD_WEBHOOK_URL')`
+   - If missing: return error message
+   - If `title` provided: POST JSON with `embeds: [{ title, description: content.slice(0, 2000) }]`
+   - Otherwise: POST JSON with `content: content.slice(0, 2000)`
+4. Register in `src/agent/tools.ts` with `mode: 'native'`
+5. Add test: mock fetch, verify correct webhook payload shape for plain and embed modes
+
+**Files touched:** `src/tools/notify.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #9 Image Viewing Tool
+
+**Steps:**
+1. Create `src/tools/image.ts` with `view_image` tool definition
+2. Parameters: `url` (required string)
+3. Implementation:
+   - `fetch(url)` with timeout
+   - Validate `content-type` starts with `image/`
+   - Reject if `content-length > 10MB`
+   - Read body as `ArrayBuffer`, convert to base64
+   - Return structured result: `{ type: 'image_result', text: 'Image from <url>', image: { type: 'base64', media_type, data } }`
+4. Update agent loop tool result handling in `src/agent/agent.ts`:
+   - When a native tool returns an object with `type: 'image_result'`, format the `ToolResultBlock` content as an array containing both a text block and an Anthropic image block
+   - This requires the `ToolResultBlock.content` update from #3
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock fetch returning PNG bytes → verify base64 encoding and content block structure
+
+**Files touched:** `src/tools/image.ts` (new), `src/agent/tools.ts`, `src/agent/agent.ts` (tool result formatting)
+
+---
+
+### #8 Summarization Tool (via Sub-Agent)
+
+**Steps:**
+1. Create `src/tools/summarize.ts` with `summarize` tool definition
+2. Parameters: `text` (required), `instructions` (optional), `max_length` (optional, enum short/medium/long)
+3. Implementation:
+   - Truncate input at 100k chars
+   - Map `max_length` to guidance string
+   - Call `deps.subAgent.complete(prompt, system)` with summarization system prompt
+   - Return `{ summary: result }`
+4. Guard: if `deps.subAgent` is undefined, return error "Sub-agent LLM not configured"
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock sub-agent, verify prompt construction and result
+
+**Files touched:** `src/tools/summarize.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #5 Auto-Generated Session Titles
+
+**Steps:**
+1. Create `src/agent/session-title.ts`:
+   - `maybeGenerateSessionTitle(store, sessionId, subAgent, messages)` function
+   - Guard: skip if session already has a title, < 2 user messages, or no sub-agent
+   - Take first 10 messages, format as text
+   - Call sub-agent with title generation prompt
+   - Post-process: strip quotes, take first line, cap at 80 chars
+   - Persist via `store.updateSessionTitle(sessionId, title)`
+2. Call from `src/agent/agent.ts` at the end of `_chatImpl` (after returning result, non-blocking)
+3. Need session ID available in agent — add `sessionId?: string` to `ChatOptions`
+4. Add test: mock sub-agent returns title → verify store updated
+
+**Files touched:** `src/agent/session-title.ts` (new), `src/agent/agent.ts`, `src/agent/types.ts`
+
+---
+
+## Wave 3 — Integration Features
+
+### #10 Custom Tool Creation + Approval Workflow
+
+**REVISED:** Sandbox-only dispatch. Custom tools are NOT exposed as native tool_use definitions. Called via `tools.call_custom_tool({ name, params })` inside execute_code. See `docs/projects/10/design.md` for rationale (prompt cache invalidation, composition, approval surface simplicity).
+
+**Steps:**
+1. Create `src/tools/custom-tool-manager.ts`:
+   - `CustomTool` type: `{ name, description, parameters (JSON Schema), code (TypeScript), approved, codeHash, secrets: string[] }`
+   - Storage: `customtool:<name>` documents in the store, content is JSON-serialized `CustomTool`
+   - `listTools()`, `getTool(name)`, `saveTool(tool)`, `approveTool(name)`, `revokeTool(name)`
+   - `getApprovedToolSummaries()`: returns `[{ name, description }]` for system prompt listing
+   - Auto-revoke: on `saveTool`, if code or parameters changed (hash mismatch), set `approved = false`
+
+2. Create `src/tools/custom-tools.ts` — agent-facing tools (all `mode: 'sandbox'`):
+   - `create_custom_tool` — agent provides name, description, parameters schema, code, optional secrets list
+   - `list_custom_tools` — returns all custom tools with approval status
+   - `call_custom_tool` — execute an approved custom tool by name (runs code via Deno sandbox with declared secrets injected)
+
+3. Register in `src/agent/tools.ts` with `mode: 'sandbox'`
+
+4. System prompt integration via #12 provider — lists approved custom tool names + descriptions for discoverability
+
+5. Add tests:
+   - Create tool → verify stored as unapproved
+   - Approve → change code → verify auto-revoked
+   - Call approved tool → verify Deno execution with secrets
+
+**Files touched:** `src/tools/custom-tool-manager.ts` (new), `src/tools/custom-tools.ts` (new), `src/agent/tools.ts`, `src/agent/types.ts`, `src/index.ts`
+
+---
+
+### #13 Multi-Screen TUI
+
+This is the largest UI feature. The current TUI is a single `App.tsx` with chat + review pages.
+
+**Steps:**
+1. **Refactor navigation** — replace `page` state string with a screen stack:
+   - Create `src/tui/types.ts` with `Screen = 'sessions' | 'chat' | 'tools' | 'secrets' | 'schedules' | 'prompt' | 'tool-detail'`
+   - Create `src/tui/Navigation.tsx` — manages screen stack, global key bindings
+
+2. **Session List Screen** (`src/tui/screens/SessionListScreen.tsx`):
+   - List sessions from `store.listSessions()` with titles and dates
+   - `n` = new session, `d` = delete, `Enter` = open in chat
+   - Display model name, secret count, tool counts in header
+
+3. **Chat Screen** — refactor from current `App.tsx`:
+   - Wire `onEvent` callback from #2 to show thinking/running indicators
+   - Show token stats bar from `ChatStats`
+   - `Escape` = back to sessions
+
+4. **Tools Screen** (`src/tui/screens/ToolsScreen.tsx`):
+   - List custom tools from `CustomToolManager` (#10)
+   - Show approval status, description
+   - `a` = approve, `r` = revoke, `Enter` = view detail
+   - Also show built-in tools (read-only)
+
+5. **Secrets Screen** (`src/tui/screens/SecretsScreen.tsx`):
+   - List secret names from `SecretManager` (#14)
+   - `a` = add new secret (prompt for name + value), `d` = delete
+   - Never display values after entry
+
+6. **Schedules Screen** (`src/tui/screens/SchedulesScreen.tsx`):
+   - List tasks from scheduler
+   - Show name, schedule, last run time, status
+   - `e` = enable/disable toggle
+
+7. **System Prompt Screen** (`src/tui/screens/SystemPromptScreen.tsx`):
+   - Display current assembled system prompt (read-only, scrollable)
+   - Useful for debugging what the agent sees
+
+8. **Global navigation keys:** `t` = tools, `s` = secrets, `c` = schedules, `p` = prompt, `q` = quit
+   - These work from any screen
+
+9. **Wire props:** Update `src/index.ts` `startTUI()` to pass scheduler, custom tool manager, and all dependencies
+
+10. Add basic rendering tests for each screen component
+
+**Files touched:** `src/tui/App.tsx` (major refactor), `src/tui/types.ts` (new), `src/tui/Navigation.tsx` (new), `src/tui/screens/` (6 new files), `src/tui/index.ts`, `src/index.ts`
+
+---
+
+## Parallel Execution Plan
+
+```
+Time →
+
+Agent A:  [#14 secrets]──────[#4 sub-agent]────────[#8 summarize]──[#10 custom tools]
+Agent B:  [#11 reasoning]────[#2 events]───────────[#5 titles]─────[#13 TUI]────────→
+Agent C:  [#1 max-iter]──────[#3 multi-tool]───────[#7 web tools]──────────────────→
+Agent D:                     [#12 prompt provider]─[#6 notify]─────[#9 image]──────→
+```
+
+**Merge gates:** Each wave must pass tests before the next wave starts consuming its outputs. Within a wave, agents work on isolated file sets and merge to a shared integration branch at wave boundaries.

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,280 @@
+// pattern: Imperative Shell — agent loop tests with mocked dependencies
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAgent } from './agent.ts';
+import type { AgentConfig, AgentDependencies } from './types.ts';
+import type { Message, ModelProvider, ModelRequest, ModelResponse } from '../model/types.ts';
+import type { CodeRuntime } from '../runtime/types.ts';
+import type { Store, DocumentRow } from '../store/store.ts';
+
+type ModelCall = {
+  request: ModelRequest;
+  toolsCount: number;
+};
+
+function makeStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string) => null as DocumentRow | null,
+    docList: (_limit?: number, _cursor?: string) => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    listMessages: () => [],
+    deleteSession: () => false,
+    saveTask: () => {},
+    getTask: () => null,
+    listTasks: () => [],
+    deleteTask: () => false,
+    updateTaskRun: () => {},
+    grantUpsert: () => {},
+    grantGet: () => null,
+    grantList: () => [],
+    grantDelete: () => false,
+    close: () => {},
+  } as unknown as Store;
+}
+
+function makeRuntime(): CodeRuntime {
+  return {
+    execute: async () => ({
+      success: true,
+      output: 'ok',
+      error: null,
+      duration_ms: 0,
+    }),
+  };
+}
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    model: 'test-model',
+    maxTokens: 1024,
+    maxToolRounds: 2,
+    contextBudget: 0.9,
+    contextLimit: 100_000,
+    modelTimeout: 30_000,
+    temperature: 0,
+    timezone: 'UTC',
+    ...overrides,
+  };
+}
+
+function makeDeps(model: ModelProvider, config: AgentConfig, personaPath: string): AgentDependencies {
+  return {
+    model,
+    runtime: makeRuntime(),
+    config,
+    personaPath,
+    store: makeStore(),
+  };
+}
+
+let personaPath: string;
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'agent-test-'));
+  personaPath = join(tempDir, 'persona.md');
+  await Bun.write(personaPath, '# Test Persona\nYou are a test agent.');
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('graceful max-iteration exhaustion', () => {
+  test('GH01.AC1.1: system nudge appears in history when maxToolRounds exhausted', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 5, output_tokens: 3 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    const overrideHistory = (result as unknown as { history?: Message[] }).history;
+    expect(overrideHistory).toBeUndefined();
+
+    expect(calls.length).toBe(3);
+    expect(calls[2]?.toolsCount).toBe(0);
+
+    expect(result.text).toBe('Forced wrap-up response');
+  });
+
+  test('GH01.AC2.1: final call uses tools: [] and produces text', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Final text' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.text).toBe('Final text');
+    const finalCall = calls[calls.length - 1];
+    expect(finalCall?.request.tools).toEqual([]);
+  });
+
+  test('GH01.AC2.2: usage stats include the forced final call', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'final' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 7, output_tokens: 11 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'x', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 13, output_tokens: 17 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    // 2 loop rounds (13+17 each) + 1 forced (7+11)
+    expect(result.stats.inputTokens).toBe(13 + 13 + 7);
+    expect(result.stats.outputTokens).toBe(17 + 17 + 11);
+  });
+
+  test('GH01.AC2.3: rounds count includes the final call (maxToolRounds + 1)', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'done' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'y', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.stats.rounds).toBe(4);
+  });
+
+  test('GH01.AC3.1: normal end_turn exit injects no nudge and makes one call', async () => {
+    let callCount = 0;
+    const model: ModelProvider = {
+      complete: async (_req) => {
+        callCount++;
+        return {
+          content: [{ type: 'text', text: 'hi' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 4, output_tokens: 2 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 5 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(callCount).toBe(1);
+    expect(result.text).toBe('hi');
+    expect(result.stats.rounds).toBe(1);
+    expect(result.stats.inputTokens).toBe(4);
+    expect(result.stats.outputTokens).toBe(2);
+  });
+
+  test('GH01.AC4.1: end-to-end always-tool_use model produces forced text response', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 9, output_tokens: 6 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('please do work');
+
+    expect(result.text).toBe('Forced wrap-up response');
+    expect(result.stats.rounds).toBe(4);
+    expect(result.stats.inputTokens).toBe(10 * 3 + 9);
+    expect(result.stats.outputTokens).toBe(5 * 3 + 6);
+
+    // Verify calls 1..3 had tools, final had tools: []
+    expect(calls.length).toBe(4);
+    expect(calls[0]?.toolsCount).toBe(1);
+    expect(calls[1]?.toolsCount).toBe(1);
+    expect(calls[2]?.toolsCount).toBe(1);
+    expect(calls[3]?.toolsCount).toBe(0);
+
+    // Verify nudge user message exists in the request sent on the final call.
+    const finalReq = calls[3]?.request;
+    const nudgeMessage = finalReq?.messages.find(
+      (m) => m.role === 'user' && m.content === '[System: Max tool calls reached. Provide final response now.]',
+    );
+    expect(nudgeMessage).toBeDefined();
+  });
+});

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -145,6 +145,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
     }
 
     // e. Tool loop
+    let exitedNormally = false;
     for (let round = 0; round < deps.config.maxToolRounds; round++) {
       let response;
       try {
@@ -180,6 +181,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
       // Check stop reason
       if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
         process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+        exitedNormally = true;
         break;
       }
 
@@ -230,6 +232,32 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
           throw new Error(`Tool dispatch failed: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
     }
 
     // f. Extract final text from last assistant message


### PR DESCRIPTION
## Summary

When the agent's tool loop exhausts `maxToolRounds`, it now produces a coherent text response instead of silently returning whatever (likely incomplete) content was in the last assistant message.

- Added an `exitedNormally` flag to `_chatImpl`'s tool loop. The flag is set only when the loop breaks via `end_turn`/`max_tokens`.
- When the loop falls through without setting the flag, the agent appends a system nudge (`[System: Max tool calls reached. Provide final response now.]`) and makes one final `model.complete` call with `tools: []`, forcing a text-only wrap-up. Usage stats and round count from the final call are accumulated into `ChatStats`.
- Added `src/agent/agent.test.ts` with six unit tests covering each acceptance criterion (nudge presence, forced `tools: []` call, usage accumulation, round count, normal-exit untouched, and an end-to-end always-tool_use integration).

## Test plan

- [x] `bun run build` succeeds
- [x] `bun test` — 6/6 tests pass for `src/agent/agent.test.ts`
- [x] Verified `tools: []` final call only fires when loop exhausts
- [x] Verified normal `end_turn` exits make exactly one model call (no extra forced call)