### PR TITLE
GH11: Extended Thinking / Reasoning Content Preservation

### DIFF
--- a/docs/projects/11/design.md
+++ b/docs/projects/11/design.md
@@ -1,0 +1,82 @@
+# #11 — Extended Thinking / Reasoning Content Preservation
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/11
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+OpenRouter config supports `reasoning` effort level (`none | low | medium | high`), but reasoning content from model responses is discarded. Not stored in conversation history, not available for compaction or debugging.
+
+## Design
+
+### Approach: Field on Message (Option A)
+
+Add `reasoning_content?: string` directly to the `Message` type. This is metadata that most consumers can ignore. The `Message` type is internal, not an API contract.
+
+### Model Response
+
+Add `reasoning_content?: string` to `ModelResponse` in `src/model/types.ts`. Each provider extracts it from the raw API response.
+
+### Provider Changes
+
+**`src/model/anthropic.ts`**
+- Claude returns thinking as `thinking` content blocks in the response
+- Concatenate all `thinking` block text into a single `reasoning_content` string
+- Set on the `ModelResponse`
+
+**`src/model/openrouter.ts`**
+- OpenRouter surfaces reasoning in response metadata (varies by underlying model)
+- Extract from the response if present
+
+**`src/model/openai-compat.ts`**
+- o1-style models may include reasoning tokens
+- Extract if present in the response structure
+
+**`src/model/ollama.ts`**
+- Local models don't emit reasoning content
+- No-op — leave `reasoning_content` undefined
+
+**`src/model/lemonade.ts`** (if separate from openai-compat)
+- Same treatment as openai-compat — extract reasoning if present in the response
+- Lemonade is an OpenAI-compat variant, so the extraction logic should mirror that provider
+
+### Agent Loop
+
+In `src/agent/agent.ts`, after building `assistantMessage` (line ~177):
+- Check `response.reasoning_content`
+- If present, attach to the message: `assistantMessage.reasoning_content = response.reasoning_content`
+
+### Compaction
+
+In `src/agent/compaction.ts` `formatConversation()`:
+- When serializing assistant messages, include reasoning content if present
+- Format as: `### assistant (reasoning)\n{reasoning_content}\n### assistant\n{content}`
+- This lets the summarizer see why decisions were made
+
+### Message Serialization
+
+In `src/agent/messages.ts`:
+- When serializing messages to/from store, preserve the `reasoning_content` field
+- JSON serialization handles this naturally if the field exists
+
+## Files Touched
+
+- `src/model/types.ts` — add `reasoning_content?: string` to `ModelResponse` and `Message`
+- `src/model/anthropic.ts` — extract from thinking blocks
+- `src/model/openrouter.ts` — extract from response metadata
+- `src/model/openai-compat.ts` — extract if present (covers lemonade)
+- `src/model/ollama.ts` — no-op (verify no crash if field absent)
+- `src/agent/agent.ts` — attach reasoning to assistant message
+- `src/agent/compaction.ts` — include reasoning in formatted conversation
+
+## Acceptance Criteria
+
+1. `ModelResponse` has optional `reasoning_content` field
+2. `Message` has optional `reasoning_content` field
+3. Anthropic provider extracts thinking blocks into `reasoning_content`
+4. OpenRouter provider extracts reasoning metadata
+5. OpenAI-compat / lemonade providers extract reasoning if present
+6. Agent loop attaches reasoning to assistant messages in history
+7. Compaction serializer includes reasoning content when formatting
+8. No display in TUI (preserved in data only)
+9. Test: mock model response with reasoning → verify stored on assistant message in history

--- a/docs/projects/11/implementation-plan/phase_01.md
+++ b/docs/projects/11/implementation-plan/phase_01.md
@@ -1,0 +1,108 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 1
+
+**Goal:** Add the `reasoning_content` optional field to `ModelResponse` and `Message` types so providers can surface reasoning and the agent loop can propagate it.
+
+**Architecture:** A single optional string field on both the response type (provider output) and the message type (conversation history). Consumers that don't care about reasoning ignore the field. No schema migrations needed — messages are serialized as JSON strings in SQLite and the field survives naturally.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime
+
+**Scope:** 3 phases total (this is phase 1 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC1: ModelResponse has optional reasoning_content field
+- **GH11.AC1.1 Success:** `ModelResponse` type includes `reasoning_content?: string`
+
+### GH11.AC2: Message has optional reasoning_content field
+- **GH11.AC2.1 Success:** `Message` type includes `reasoning_content?: string`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `reasoning_content` to `ModelResponse`
+
+**Verifies:** GH11.AC1.1
+
+**Files:**
+- Modify: `src/model/types.ts:59-63`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `ModelResponse` type. This is the provider-facing output — each provider sets it when reasoning content is present in the API response.
+
+In `src/model/types.ts`, the current `ModelResponse` type (lines 59-63) is:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+};
+```
+
+Add the field:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The field is optional so all existing provider return sites remain valid.
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add `reasoning_content` to `Message`
+
+**Verifies:** GH11.AC2.1
+
+**Files:**
+- Modify: `src/model/types.ts:35-38`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `Message` type. This is the conversation history type — the agent loop attaches reasoning content to assistant messages so it persists across the session.
+
+The current `Message` type (lines 35-38) is:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+};
+```
+
+Add the field:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. All existing message construction sites pass because the field is optional.
+
+**Commit:** `feat(types): add reasoning_content field to ModelResponse and Message`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/11/implementation-plan/phase_02.md
+++ b/docs/projects/11/implementation-plan/phase_02.md
@@ -1,0 +1,257 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 2
+
+**Goal:** Extract reasoning content from each model provider's API response and set it on the `ModelResponse`.
+
+**Architecture:** Each provider has a different response format for reasoning. Anthropic returns `thinking` content blocks. OpenRouter surfaces a `reasoning` string on the assistant message. OpenAI-compat may include reasoning in the response (o1-style models). Ollama does not emit reasoning — no-op. Each provider extracts and concatenates reasoning text into the single `reasoning_content` string field added in Phase 1.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, `@anthropic-ai/sdk` (v0.39+), `@openrouter/sdk` (v0.12+)
+
+**Scope:** 3 phases total (this is phase 2 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC3: Anthropic provider extracts thinking blocks into reasoning_content
+- **GH11.AC3.1 Success:** When Claude returns `thinking` content blocks, they are concatenated into `reasoning_content` on the `ModelResponse`
+- **GH11.AC3.2 No-op:** When no thinking blocks are present, `reasoning_content` is `undefined`
+
+### GH11.AC4: OpenRouter provider extracts reasoning metadata
+- **GH11.AC4.1 Success:** When OpenRouter response includes `reasoning` on the assistant message, it is set as `reasoning_content`
+- **GH11.AC4.2 No-op:** When `reasoning` is absent/null, `reasoning_content` is `undefined`
+
+### GH11.AC5: OpenAI-compat / lemonade providers extract reasoning if present
+- **GH11.AC5.1 Success:** When response includes a `reasoning_content` field on the message, it is extracted
+- **GH11.AC5.2 No-op:** When field is absent, `reasoning_content` is `undefined`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Anthropic provider — extract thinking blocks
+
+**Verifies:** GH11.AC3.1, GH11.AC3.2
+
+**Files:**
+- Modify: `src/model/anthropic.ts:23-37` (mapContentBlock function)
+- Modify: `src/model/anthropic.ts:70-89` (complete function, response mapping + return)
+
+**Implementation:**
+
+The Anthropic SDK's `ContentBlock` union already includes `ThinkingBlock` (`{ type: 'thinking'; thinking: string; signature: string }`) and `RedactedThinkingBlock` (`{ type: 'redacted_thinking' }`). The current `mapContentBlock` function has a fallback for unknown block types but does not handle `thinking` explicitly.
+
+Two changes needed:
+
+**1. Update `mapContentBlock` to skip thinking blocks.**
+
+Thinking blocks should not be mapped into the agent's `ContentBlock[]` — they are metadata, not content the agent acts on. The function currently falls through to a text fallback for unknown types. Add an explicit case that returns `null` for thinking blocks, and filter nulls from the result.
+
+Replace the current `mapContentBlock` and the line that calls it:
+
+```typescript
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
+  if (block.type === 'text') {
+    return { type: 'text', text: block.text };
+  }
+  if (block.type === 'tool_use') {
+    return {
+      type: 'tool_use',
+      id: block.id,
+      name: block.name,
+      input: block.input as Record<string, unknown>,
+    };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
+  }
+  // Fallback: treat unknown block types as text
+  return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
+}
+```
+
+Update the content mapping in `complete()` (currently line 74):
+
+```typescript
+const content: Array<ContentBlock> = response.content
+  .map(mapContentBlock)
+  .filter((b): b is ContentBlock => b !== null);
+```
+
+**2. Extract reasoning content from thinking blocks.**
+
+After the content mapping, concatenate all `thinking` block text into `reasoning_content`:
+
+```typescript
+const thinkingTexts = response.content
+  .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+  .map((b) => b.thinking);
+const reasoning_content = thinkingTexts.length > 0
+  ? thinkingTexts.join('\n\n')
+  : undefined;
+```
+
+Then include it in the return:
+
+```typescript
+return {
+  content,
+  stop_reason: mapStopReason(response.stop_reason),
+  usage: {
+    input_tokens: response.usage.input_tokens,
+    output_tokens: response.usage.output_tokens,
+    cache_creation_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_creation_input_tokens'] as
+        number | null | undefined ?? null,
+    cache_read_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
+        number | null | undefined ?? null,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(anthropic): extract thinking blocks into reasoning_content`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: OpenRouter provider — extract reasoning field
+
+**Verifies:** GH11.AC4.1, GH11.AC4.2
+
+**Files:**
+- Modify: `src/model/openrouter.ts:223-237` (return statement in complete function)
+
+**Implementation:**
+
+The OpenRouter SDK's `ChatAssistantMessage` type includes `reasoning?: string | null | undefined`. The current code accesses `choice.message` but does not read `reasoning`.
+
+After the existing debug log line (line 228), extract the reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+  ? choice.message.reasoning
+  : undefined;
+```
+
+Then include it in the return object (currently lines 230-237):
+
+```typescript
+return {
+  content: mapResponseContent(choice.message),
+  stop_reason: mapFinishReason(choice.finishReason),
+  usage: {
+    input_tokens: response.usage?.promptTokens ?? 0,
+    output_tokens: response.usage?.completionTokens ?? 0,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openrouter): extract reasoning into reasoning_content`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: OpenAI-compat provider — extract reasoning if present
+
+**Verifies:** GH11.AC5.1, GH11.AC5.2
+
+**Files:**
+- Modify: `src/model/openai-compat.ts:34-45` (OpenAIChoice type)
+- Modify: `src/model/openai-compat.ts:270-281` (return statement in complete function)
+
+**Implementation:**
+
+Some OpenAI-compatible providers (e.g., o1-style models, DeepSeek-R1 via compatible endpoints) return reasoning in the response. The field name varies but the most common convention is `reasoning_content` on the message object. The current `OpenAIChoice` type does not include this field.
+
+**1. Extend the `OpenAIChoice` type** to accept an optional reasoning field on the message:
+
+```typescript
+type OpenAIChoice = {
+  message: {
+    role: 'assistant';
+    content: string | null;
+    reasoning_content?: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }>;
+  };
+  finish_reason: string;
+};
+```
+
+**2. Extract reasoning in the return.** After getting `choice` (line 272), extract reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+  ? choice.message.reasoning_content
+  : undefined;
+```
+
+Include in the return:
+
+```typescript
+return {
+  content: mapResponseContent(choice),
+  stop_reason: mapFinishReason(choice.finish_reason),
+  usage: {
+    input_tokens: data.usage.prompt_tokens,
+    output_tokens: data.usage.completion_tokens,
+  },
+  reasoning_content,
+};
+```
+
+**Note:** This also covers the `lemonade` provider case from the design — there is no separate `src/model/lemonade.ts` file. Lemonade uses the OpenAI-compat provider, so this change covers both.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openai-compat): extract reasoning_content from response`
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Ollama provider — verify no-op
+
+**Verifies:** None (verification that existing provider doesn't crash with the new optional field)
+
+**Files:**
+- No modifications to `src/model/ollama.ts`
+
+**Implementation:**
+
+No code changes. The Ollama provider's `complete()` method returns a `ModelResponse` without `reasoning_content`, which is valid because the field is optional. Local models served by Ollama do not emit reasoning content.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The Ollama provider compiles cleanly without setting `reasoning_content` because the field is optional on `ModelResponse`.
+
+No commit needed for this task — it's a verification step only.
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/phase_03.md
+++ b/docs/projects/11/implementation-plan/phase_03.md
@@ -1,0 +1,308 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 3
+
+**Goal:** Wire reasoning content through the agent loop (attach to assistant messages in history), include it in compaction serialization, and add a test proving the end-to-end flow.
+
+**Architecture:** The agent loop in `agent.ts` builds an `assistantMessage` from the model response. We attach `reasoning_content` from the response to the message. The compaction serializer in `compaction.ts` already formats messages into markdown — we prepend reasoning content as a separate section when present. A new test file verifies the full flow: mock model returns reasoning, verify it lands on the history message and appears in compaction output.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, Bun test runner
+
+**Scope:** 3 phases total (this is phase 3 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH11.AC6: Agent loop attaches reasoning to assistant messages in history
+- **GH11.AC6.1 Success:** When `response.reasoning_content` is present, it is set on the assistant message pushed to history
+- **GH11.AC6.2 No-op:** When `response.reasoning_content` is undefined, the message has no `reasoning_content` field
+
+### GH11.AC7: Compaction serializer includes reasoning content when formatting
+- **GH11.AC7.1 Success:** When an assistant message has `reasoning_content`, `formatConversation()` includes it in the output as `### assistant (reasoning)\n{reasoning_content}` before the main `### assistant\n{content}` block
+- **GH11.AC7.2 No-op:** When no `reasoning_content` is present, formatting is unchanged
+
+### GH11.AC8: No display in TUI (preserved in data only)
+- **GH11.AC8.1 Verification:** No changes to any TUI component. Reasoning content exists only on the `Message` type and in compaction output.
+
+### GH11.AC9: Test — mock model response with reasoning, verify stored on assistant message
+- **GH11.AC9.1 Success:** A test with a mock model returning `reasoning_content` verifies the field appears on the assistant message in history
+- **GH11.AC9.2 Success:** A test verifies `formatConversation()` includes reasoning in the serialized output
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Agent loop — attach reasoning to assistant message
+
+**Verifies:** GH11.AC6.1, GH11.AC6.2
+
+**Files:**
+- Modify: `src/agent/agent.ts:177` (assistant message construction)
+
+**Implementation:**
+
+In `_chatImpl`, after the model call, the assistant message is constructed at line 177:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+```
+
+Add reasoning content propagation immediately after this line:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+if (response.reasoning_content) {
+  assistantMessage.reasoning_content = response.reasoning_content;
+}
+```
+
+This is a simple conditional assignment. When `reasoning_content` is undefined (the common case for most models), nothing happens. When present (e.g., Anthropic thinking blocks, OpenRouter reasoning), it's preserved on the message in history.
+
+**Note on TUI (GH11.AC8):** No TUI files need changes. The `ChatResult` type returned by `chat()` contains only `text` and `stats` — reasoning content is preserved in the internal `history` array and in compaction output, but never surfaced to the UI layer.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(agent): attach reasoning_content to assistant messages in history`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Compaction — include reasoning in formatted conversation
+
+**Verifies:** GH11.AC7.1, GH11.AC7.2
+
+**Files:**
+- Modify: `src/agent/compaction.ts:19-37` (formatConversation function)
+
+**Implementation:**
+
+The `formatConversation` function serializes messages into markdown for context compaction. Currently it formats each message as `### {role}\n{content}`. When an assistant message has `reasoning_content`, we should include it so the summarizer can see the model's reasoning chain.
+
+The current function (lines 19-37):
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+      return `### ${msg.role}\n${content}`;
+    })
+    .join('\n\n');
+}
+```
+
+Replace it with:
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
+    })
+    .join('\n\n');
+}
+```
+
+When `reasoning_content` is present, the output for that message becomes:
+
+```
+### assistant (reasoning)
+{reasoning text here}
+
+### assistant
+{actual response content}
+```
+
+When absent, output is identical to the previous format: `### assistant\n{content}`.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(compaction): include reasoning_content in formatted conversation`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: Test — reasoning content flows through agent loop
+
+**Verifies:** GH11.AC9.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Implementation:**
+
+Create a test that exercises the agent loop with a mock model that returns `reasoning_content`. The test verifies that the reasoning appears on the assistant message in history.
+
+The test needs to mock several dependencies:
+- `ModelProvider` — returns a `ModelResponse` with `reasoning_content` and `stop_reason: 'end_turn'`
+- `CodeRuntime` — not needed (model stops on first call, no tool use)
+- `Store` — minimal mock that returns empty docs
+- `personaPath` — points to a temp file with a basic persona
+
+Key behavior to test:
+- Call `agent.chat("test")` with a model mock that returns `reasoning_content: "I thought about this carefully"`
+- The agent's internal history is not directly exposed, but we can verify via a second call: override conversation with the history from a captured mock
+- Alternatively, since `createAgent` doesn't expose history, test the `formatConversation` integration path instead (see Task 4)
+
+A more direct approach: since the agent returns `ChatResult` with only `text` and `stats`, and reasoning is preserved internally, the most valuable test is to verify that a model response with reasoning doesn't break the agent loop and that the text response is correctly extracted. The reasoning preservation is structural (type system enforces it once the field is set).
+
+However, for a proper behavioral test, we can use `conversationOverride` to inject a message with reasoning and verify the model receives it back on subsequent calls. Here's the approach:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+
+// Track what the model receives so we can inspect history
+const receivedMessages: Message[][] = [];
+
+const mockModel = {
+  async complete(request: { messages: ReadonlyArray<Message> }): Promise<ModelResponse> {
+    receivedMessages.push([...request.messages]);
+    return {
+      content: [{ type: 'text', text: 'I have responded.' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 5 },
+      reasoning_content: 'Let me think step by step about this problem.',
+    };
+  },
+};
+```
+
+The full test creates an agent with minimal mocks, calls `chat()`, then calls `chat()` again and inspects the messages sent to the model on the second call. The second call's messages should include the assistant message from the first call, which should have `reasoning_content` set.
+
+**Testing pattern notes:**
+- Bun test runner is used (`bun test`)
+- No existing test files in the codebase, so this establishes the pattern
+- The persona file must exist — use `Bun.write` to create a temp file
+- Store mock needs `docGet`, `docList` methods minimum (used by `loadCoreMemoryFromStore` and skill listing)
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/agent.test.ts`
+Expected: Test passes.
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Test — formatConversation includes reasoning
+
+**Verifies:** GH11.AC9.2
+
+**Files:**
+- Create: `src/agent/compaction.test.ts`
+
+**Implementation:**
+
+Test the `formatConversation` function directly. This is a pure function — much easier to test in isolation than the full agent loop.
+
+Problem: `formatConversation` is not exported (it's a module-private function in `compaction.ts`). Two options:
+
+**Option A (preferred):** Export `formatConversation` from `compaction.ts`. It's a pure function with no side effects — there's no reason to hide it, and exporting it enables direct testing.
+
+**Option B:** Test indirectly through `compactContext`, which is exported but requires store + model mocks.
+
+Go with Option A. Add `export` to `formatConversation`:
+
+In `src/agent/compaction.ts`, change line 19 from:
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+to:
+```typescript
+export function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+
+Then create the test:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/compaction.test.ts`
+Expected: Both tests pass.
+
+**Commit:** `test(GH11): add tests for reasoning_content in agent loop and compaction`
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/test-requirements.md
+++ b/docs/projects/11/implementation-plan/test-requirements.md
@@ -1,0 +1,51 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+### Automated Tests
+
+| AC | Description | Test Type | Test File | Notes |
+|----|-------------|-----------|-----------|-------|
+| GH11.AC1.1 | `ModelResponse` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler (`tsc --noEmit`). No runtime test needed. |
+| GH11.AC2.1 | `Message` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler. No runtime test needed. |
+| GH11.AC3.1 | Anthropic extracts thinking blocks | Type check | N/A | Structural — verified by compiler. Integration testing requires live Anthropic API with extended thinking enabled. |
+| GH11.AC3.2 | Anthropic no-op when no thinking blocks | Type check | N/A | Field is optional, absence is the default. Compiler verifies. |
+| GH11.AC4.1 | OpenRouter extracts reasoning | Type check | N/A | Structural — verified by compiler. Integration testing requires live OpenRouter API with reasoning model. |
+| GH11.AC4.2 | OpenRouter no-op when no reasoning | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC5.1 | OpenAI-compat extracts reasoning_content | Type check | N/A | Structural — verified by compiler. |
+| GH11.AC5.2 | OpenAI-compat no-op when absent | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC6.1 | Agent loop attaches reasoning to assistant message | Unit | `src/agent/agent.test.ts` | Mock model returns reasoning, verify it appears in history on next model call. |
+| GH11.AC6.2 | Agent loop no-op when reasoning absent | Unit | `src/agent/agent.test.ts` | Mock model returns no reasoning, verify message has no `reasoning_content`. |
+| GH11.AC7.1 | Compaction includes reasoning in formatted output | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` with a message containing `reasoning_content`. |
+| GH11.AC7.2 | Compaction unchanged when no reasoning | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` without `reasoning_content` — output matches prior format. |
+| GH11.AC9.1 | Test: mock model with reasoning, verify on assistant message | Unit | `src/agent/agent.test.ts` | Core behavioral test of the feature. |
+| GH11.AC9.2 | Test: formatConversation includes reasoning | Unit | `src/agent/compaction.test.ts` | Core behavioral test of compaction serialization. |
+
+### Human Verification
+
+| AC | Description | Verification Approach |
+|----|-------------|----------------------|
+| GH11.AC8.1 | No display in TUI | Verify no TUI files were modified. Run `git diff --name-only` after implementation and confirm no files under `src/tui/` appear. |
+| GH11.AC3.1 (integration) | Anthropic thinking blocks extracted in production | Manually test with a Claude model that supports extended thinking. Set `reasoning: high` in config, send a request, inspect debug logs for reasoning content. |
+| GH11.AC4.1 (integration) | OpenRouter reasoning extracted in production | Manually test with an OpenRouter model that returns reasoning. Inspect debug logs. |
+
+## Test Execution
+
+```bash
+# Run all tests
+cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test
+
+# Run specific test files
+bun test src/agent/agent.test.ts
+bun test src/agent/compaction.test.ts
+
+# Type checking (covers AC1-AC5 structurally)
+npx tsc --noEmit
+```
+
+## Summary
+
+- **4 automated unit tests** across 2 test files
+- **Type checking** covers the structural correctness of all provider changes (AC1-AC5)
+- **3 human verification items** for TUI non-impact and live integration testing
+- Provider extraction logic (AC3-AC5) is structural — the code either sets the field from the API response or doesn't. The extraction patterns are straightforward conditional reads with no branching logic that warrants mocking the HTTP layer.

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,184 @@
+// pattern: Imperative Shell (test) — exercises agent loop with mocks
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message, ModelRequest } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+import type { Store, DocumentRow, GrantRow } from '../store/store.ts';
+import type { CodeRuntime, ExecutionResult } from '../runtime/types.ts';
+
+function createNoopStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string): DocumentRow | null => null,
+    docList: () => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    getMessages: () => [],
+    clearMessages: () => {},
+    saveTask: () => {},
+    listTasks: () => [],
+    getTask: () => null,
+    updateTaskRun: () => {},
+    deleteTask: () => false,
+    saveGrant: () => {},
+    getGrant: (): GrantRow | null => null,
+    listGrants: () => [],
+    updateGrantStatus: () => {},
+    updateGrantSecrets: () => {},
+    deleteGrant: () => false,
+    close: () => {},
+  };
+}
+
+const noopRuntime: CodeRuntime = {
+  async execute(): Promise<ExecutionResult> {
+    return { success: true, output: '', error: null, duration_ms: 0 };
+  },
+};
+
+describe('agent reasoning_content propagation', () => {
+  let tmpDir: string;
+  let personaPath: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gh11-agent-test-'));
+    personaPath = join(tmpDir, 'persona.md');
+    writeFileSync(personaPath, '# Test Persona\nYou are a test agent.');
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('reasoning_content from model response appears on history message sent to next call', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'I have responded.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+        reasoning_content: 'Let me think step by step about this problem.',
+      },
+      {
+        content: [{ type: 'text', text: 'Second response.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+
+    const first = await agent.chat('first user message');
+    expect(first.text).toBe('I have responded.');
+
+    await agent.chat('second user message');
+
+    // The second call's messages should include the assistant message from the first call.
+    // That assistant message must carry reasoning_content.
+    const secondCallMessages = receivedMessages[1];
+    expect(secondCallMessages).toBeDefined();
+
+    const assistantMessage = secondCallMessages!.find(
+      (m) => m.role === 'assistant',
+    );
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBe(
+      'Let me think step by step about this problem.',
+    );
+  });
+
+  test('absent reasoning_content does not pollute the assistant history message', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'No reasoning here.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      {
+        content: [{ type: 'text', text: 'Done.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+    await agent.chat('first');
+    await agent.chat('second');
+
+    const secondCallMessages = receivedMessages[1];
+    const assistantMessage = secondCallMessages!.find((m) => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBeUndefined();
+  });
+});

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -175,6 +175,9 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
 
       // Append assistant response
       const assistantMessage: Message = { role: 'assistant', content: response.content };
+      if (response.reasoning_content) {
+        assistantMessage.reasoning_content = response.reasoning_content;
+      }
       history.push(assistantMessage);
 
       // Check stop reason

--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -1,0 +1,36 @@
+// pattern: Functional Core (test)
+
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -16,7 +16,7 @@ const RECENT_NOTES_COUNT = 3;
 /**
  * Format a conversation history as readable markdown.
  */
-function formatConversation(messages: ReadonlyArray<Message>): string {
+export function formatConversation(messages: ReadonlyArray<Message>): string {
   return messages
     .map((msg) => {
       const content =
@@ -32,7 +32,13 @@ function formatConversation(messages: ReadonlyArray<Message>): string {
               })
               .filter(Boolean)
               .join('\n');
-      return `### ${msg.role}\n${content}`;
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
     })
     .join('\n\n');
 }

--- a/src/model/anthropic.ts
+++ b/src/model/anthropic.ts
@@ -20,7 +20,7 @@ function mapStopReason(reason: string | null): StopReason {
   }
 }
 
-function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
   if (block.type === 'text') {
     return { type: 'text', text: block.text };
   }
@@ -31,6 +31,9 @@ function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
       name: block.name,
       input: block.input as Record<string, unknown>,
     };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
   }
   // Fallback: treat unknown block types as text
   return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
@@ -71,7 +74,16 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
         timeout: request.timeout ?? 120_000,
       });
 
-      const content: Array<ContentBlock> = response.content.map(mapContentBlock);
+      const content: Array<ContentBlock> = response.content
+        .map(mapContentBlock)
+        .filter((b): b is ContentBlock => b !== null);
+
+      const thinkingTexts = response.content
+        .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+        .map((b) => b.thinking);
+      const reasoning_content = thinkingTexts.length > 0
+        ? thinkingTexts.join('\n\n')
+        : undefined;
 
       return {
         content,
@@ -86,6 +98,7 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
             (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
               number | null | undefined ?? null,
         },
+        reasoning_content,
       };
     },
   };

--- a/src/model/openai-compat.ts
+++ b/src/model/openai-compat.ts
@@ -35,6 +35,7 @@ type OpenAIChoice = {
   message: {
     role: 'assistant';
     content: string | null;
+    reasoning_content?: string | null;
     tool_calls?: Array<{
       id: string;
       type: 'function';
@@ -271,6 +272,10 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
 
         const choice = data.choices[0]!;
 
+        const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+          ? choice.message.reasoning_content
+          : undefined;
+
         return {
           content: mapResponseContent(choice),
           stop_reason: mapFinishReason(choice.finish_reason),
@@ -278,6 +283,7 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
             input_tokens: data.usage.prompt_tokens,
             output_tokens: data.usage.completion_tokens,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/openrouter.ts
+++ b/src/model/openrouter.ts
@@ -227,6 +227,10 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
 
         process.stderr.write(`[openrouter] finish_reason=${choice.finishReason} tool_calls=${choice.message.toolCalls?.length ?? 0} content_len=${typeof choice.message.content === 'string' ? choice.message.content.length : 0}\n`);
 
+        const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+          ? choice.message.reasoning
+          : undefined;
+
         return {
           content: mapResponseContent(choice.message),
           stop_reason: mapFinishReason(choice.finishReason),
@@ -234,6 +238,7 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
             input_tokens: response.usage?.promptTokens ?? 0,
             output_tokens: response.usage?.completionTokens ?? 0,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -35,6 +35,7 @@ export type ToolDefinition = {
 export type Message = {
   role: 'user' | 'assistant';
   content: string | Array<ContentBlock>;
+  reasoning_content?: string;
 };
 
 export type ModelRequest = {
@@ -60,6 +61,7 @@ export type ModelResponse = {
   content: Array<ContentBlock>;
   stop_reason: StopReason;
   usage: UsageStats;
+  reasoning_content?: string;
 };
 
 export type ModelProvider = {


### PR DESCRIPTION
## Summary

Preserves model reasoning content (Anthropic thinking blocks, OpenRouter `reasoning`, OpenAI-compat `reasoning_content`) through the agent loop and into compaction output. Reasoning is preserved in conversation history and surfaced to the summarizer during context compaction; it is intentionally not displayed in the TUI.

- Adds optional `reasoning_content?: string` to `ModelResponse` and `Message` types.
- Provider extraction: Anthropic concatenates `thinking` blocks (and now skips them from `ContentBlock[]`); OpenRouter reads `choice.message.reasoning`; OpenAI-compat reads `choice.message.reasoning_content`. Ollama is a verified no-op.
- Agent loop attaches `response.reasoning_content` to the assistant message pushed onto history.
- `formatConversation()` (now exported) emits `### {role} (reasoning)` before the main `### {role}` block when reasoning is present.

## Acceptance Criteria

All of GH11.AC1 through GH11.AC9 are covered. New tests in `src/agent/compaction.test.ts` and `src/agent/agent.test.ts` verify the end-to-end flow.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 4 passing across 2 files (no prior tests existed; this PR establishes the pattern)
- [x] `bun run build` succeeds
- [ ] Manual smoke: run agent against an Anthropic thinking-enabled model and verify `reasoning_content` appears in compaction snapshots