### PR TITLE
GH02: Event Emission / Lifecycle Hooks

### DIFF
--- a/docs/projects/1/design.md
+++ b/docs/projects/1/design.md
@@ -1,0 +1,66 @@
+# #1 — Graceful Max-Iteration Exhaustion
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/1
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+When `maxToolRounds` is hit, the for-loop in `_chatImpl` exits silently. The text extraction logic at the end grabs whatever was in the last assistant message — often a `tool_use` block with no text, or mid-thought content.
+
+## Design
+
+### Flag-based detection
+
+Add a `let exitedNormally = false` flag before the for-loop. Set it `true` inside the `end_turn`/`max_tokens` break (line ~183). After the for-loop, check the flag.
+
+### Forced final response
+
+If `!exitedNormally`:
+
+1. Push a system nudge as a user message:
+   ```
+   history.push({ role: 'user', content: '[System: Max tool calls reached. Provide final response now.]' });
+   ```
+
+2. Make one final model call with **no tools**:
+   ```
+   const finalResponse = await deps.model.complete({
+     system: systemPrompt,
+     messages: history,
+     tools: [],          // forces text-only response
+     model: deps.config.model,
+     max_tokens: deps.config.maxTokens,
+     temperature: deps.config.temperature,
+     timeout: deps.config.modelTimeout,
+   });
+   ```
+
+3. Accumulate usage stats:
+   ```
+   rounds++;
+   totalInputTokens += finalResponse.usage.input_tokens;
+   totalOutputTokens += finalResponse.usage.output_tokens;
+   ```
+
+4. Push final assistant response to history:
+   ```
+   history.push({ role: 'assistant', content: finalResponse.content });
+   ```
+
+5. Existing text extraction logic at the end of `_chatImpl` handles the rest — it finds the last assistant message and extracts text blocks.
+
+### Why `tools: []` works
+
+With no tools in the request, the model cannot return `tool_use` blocks. It must produce text. This guarantees a coherent wrap-up response.
+
+## Files Touched
+
+- `src/agent/agent.ts` — ~20 lines after the for-loop
+
+## Acceptance Criteria
+
+1. When maxToolRounds exhausted, a system nudge message appears in history
+2. A final model call with `tools: []` produces a text response
+3. Usage stats from the final call are included in `ChatStats`
+4. `rounds` count includes the final call
+5. Test: mock model that always returns `tool_use` → verify final forced text response after maxToolRounds

--- a/docs/projects/1/implementation-plan/phase_01.md
+++ b/docs/projects/1/implementation-plan/phase_01.md
@@ -1,0 +1,204 @@
+# GH01: Graceful Max-Iteration Exhaustion — Implementation Plan
+
+**Goal:** When the agent's tool loop exhausts `maxToolRounds`, produce a coherent text response instead of silently returning whatever was in the last (likely incomplete) assistant message.
+
+**Architecture:** Add an `exitedNormally` flag to the existing `for` loop in `_chatImpl`. When the loop exits without an `end_turn`/`max_tokens` break, push a system nudge and make one final model call with `tools: []` to force a text-only wrap-up.
+
+**Tech Stack:** TypeScript, Bun test runner (`bun:test`)
+
+**Scope:** 1 phase (complete feature)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH01.AC1: System nudge on exhaustion
+- **GH01.AC1.1 Success:** When maxToolRounds exhausted, a system nudge message appears in history
+
+### GH01.AC2: Forced text-only final call
+- **GH01.AC2.1 Success:** A final model call with `tools: []` produces a text response
+- **GH01.AC2.2 Success:** Usage stats from the final call are included in `ChatStats`
+- **GH01.AC2.3 Success:** `rounds` count includes the final call
+
+### GH01.AC3: Normal exit unaffected
+- **GH01.AC3.1 Success:** When the loop exits via `end_turn` or `max_tokens`, no nudge is injected and no extra model call is made
+
+### GH01.AC4: Integration test
+- **GH01.AC4.1 Success:** Mock model that always returns `tool_use` produces a final forced text response after maxToolRounds
+
+---
+
+## Phase 1: Flag-Based Exhaustion Detection and Forced Final Response
+
+This is a functionality phase. All changes are in `src/agent/agent.ts` with a new test file at `src/agent/agent.test.ts`.
+
+<!-- START_SUBCOMPONENT_A (tasks 1-4) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `exitedNormally` flag and forced final response logic
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1
+
+**Files:**
+- Modify: `src/agent/agent.ts:147-233` (the tool loop and the code immediately after it)
+
+**Implementation:**
+
+Before the `for` loop at line 148, add:
+
+```typescript
+let exitedNormally = false;
+```
+
+Inside the `end_turn`/`max_tokens` break at line 181-184, set the flag before breaking:
+
+```typescript
+if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
+  process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+  exitedNormally = true;
+  break;
+}
+```
+
+After the closing `}` of the `for` loop (line 233) and before the `// f. Extract final text` comment (line 235), insert the forced final response block:
+
+```typescript
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
+    }
+```
+
+**Key details:**
+- `tools: []` prevents the model from returning `tool_use` blocks — it must produce text.
+- The nudge is a plain string user message, not an array of content blocks. This matches how the agent already pushes user messages (line 121).
+- Usage stats are accumulated into the existing `totalInputTokens`/`totalOutputTokens`/`rounds` variables. The final `ChatStats` object at line 246 already reads from these, so no further changes needed.
+- The existing text extraction logic at line 235-263 handles the rest — it finds the last assistant message and extracts text blocks. Since the forced response is the last assistant message and contains only text blocks (no `tool_use` possible), it works as-is.
+
+**Verification:**
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+**Commit:** `feat(agent): add exitedNormally flag and forced final response on max-iteration exhaustion`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Write tests for max-iteration exhaustion
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1, GH01.AC4.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Context for test construction:**
+
+The `createAgent` function (exported from `src/agent/agent.ts`) takes an `AgentDependencies` object. The key deps to mock are:
+
+1. **`model: ModelProvider`** — needs a `complete()` method returning `ModelResponse`. The mock controls `stop_reason` and `content` to simulate tool_use vs end_turn behaviour.
+
+2. **`runtime: CodeRuntime`** — needs an `execute()` method returning `ExecutionResult`. For these tests, the runtime mock just returns a success result since we're testing loop exit behaviour, not tool execution.
+
+3. **`store: Store`** — the agent calls `store.docGet('self')` and `store.docList(500)` during prompt building. Mock these to return minimal data.
+
+4. **`config: AgentConfig`** — set `maxToolRounds` to a small number (e.g., 2 or 3) to trigger exhaustion quickly.
+
+5. **`personaPath: string`** — points to a file read with `Bun.file().text()`. Create a temp file or use an existing fixture.
+
+The agent also writes to `src/runtime/deno/tools.ts` via `Bun.write`. Ensure the directory exists or mock accordingly.
+
+**Testing:**
+
+Tests must verify each AC listed above:
+
+- **GH01.AC1.1:** After the model returns `tool_use` for every round up to `maxToolRounds`, assert that history contains a user message with content `'[System: Max tool calls reached. Provide final response now.]'`.
+
+- **GH01.AC2.1:** Assert the mock model's `complete` was called one final time after the loop with `tools: []` in the request, and the returned `ChatResult.text` contains the forced response text.
+
+- **GH01.AC2.2:** Assert `ChatResult.stats.inputTokens` and `stats.outputTokens` include the usage from the final forced call (sum of all rounds including the forced one).
+
+- **GH01.AC2.3:** Assert `ChatResult.stats.rounds` equals `maxToolRounds + 1` (the loop rounds plus the forced final call).
+
+- **GH01.AC3.1:** When the model returns `end_turn` on the first call, assert no nudge message in history, `stats.rounds` equals 1, and `complete` was called exactly once.
+
+- **GH01.AC4.1:** End-to-end mock scenario: model always returns `tool_use` except when called with `tools: []` (then returns text). Verify the agent returns the forced text response and all stats are correct.
+
+**Mock strategy:**
+
+The model mock should track call count and inspect the `tools` parameter:
+- When `tools` contains `EXECUTE_CODE_TOOL`: return a `tool_use` response with a dummy tool call
+- When `tools` is `[]`: return an `end_turn` response with a text block containing known text (e.g., `"Forced wrap-up response"`)
+
+The runtime mock returns `{ success: true, output: 'ok', error: null, duration_ms: 0 }` for all executions.
+
+The store mock returns `null` for `docGet` and `{ documents: [], total: 0 }` for `docList`.
+
+Create a temp persona file using `Bun.write` in a `beforeAll` block pointing to a temp directory (`import { mkdtemp } from 'node:fs/promises'`), containing minimal persona text.
+
+**Verification:**
+Run: `bun test`
+Expected: All tests pass
+
+**Commit:** `test(agent): add tests for graceful max-iteration exhaustion`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Run full verification
+
+**Files:** None (verification only)
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+Run: `bun test`
+Expected: All tests pass
+
+Run: `bun run build && bun test`
+Expected: Both succeed
+
+This task has no commit — it's a verification gate.
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Final commit
+
+**Files:** None (commit only — all changes from Tasks 1-2 should already be committed)
+
+**Verification:**
+
+Run: `git status`
+Expected: Working tree clean, all changes committed
+
+Run: `git log --oneline -3`
+Expected: Two commits visible — implementation and tests
+
+This task exists to ensure everything is committed and the branch is clean.
+<!-- END_TASK_4 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/1/implementation-plan/test-requirements.md
+++ b/docs/projects/1/implementation-plan/test-requirements.md
@@ -1,0 +1,18 @@
+# GH01: Graceful Max-Iteration Exhaustion — Test Requirements
+
+Maps each acceptance criterion to automated tests. All tests are unit tests in `src/agent/agent.test.ts` using `bun:test`.
+
+## Automated Tests
+
+| AC ID | Criterion | Test Type | Test File | Test Description |
+|-------|-----------|-----------|-----------|------------------|
+| GH01.AC1.1 | System nudge appears in history on exhaustion | unit | `src/agent/agent.test.ts` | After model returns `tool_use` for all `maxToolRounds`, inspect history for user message containing `'[System: Max tool calls reached. Provide final response now.]'` |
+| GH01.AC2.1 | Final call with `tools: []` produces text | unit | `src/agent/agent.test.ts` | Mock model returns text when `tools` is `[]`. Assert `ChatResult.text` matches the forced response text. Assert model was called with `tools: []` on the final call. |
+| GH01.AC2.2 | Final call usage stats included in ChatStats | unit | `src/agent/agent.test.ts` | Mock model returns known usage values per call. Assert `stats.inputTokens` and `stats.outputTokens` equal the sum across all calls including the forced one. |
+| GH01.AC2.3 | Rounds count includes final call | unit | `src/agent/agent.test.ts` | With `maxToolRounds: N`, assert `stats.rounds` equals `N + 1` when exhaustion occurs. |
+| GH01.AC3.1 | Normal exit unaffected | unit | `src/agent/agent.test.ts` | Model returns `end_turn` immediately. Assert no nudge in history, `stats.rounds` equals 1, model called exactly once. |
+| GH01.AC4.1 | Integration: always-tool_use model forced to text | unit | `src/agent/agent.test.ts` | End-to-end scenario: model returns `tool_use` until `tools: []`, then returns text. Verify returned text, correct round count, correct token sums. |
+
+## Human Verification
+
+None required. All acceptance criteria are testable via automated unit tests with mocked dependencies.

--- a/docs/projects/11/design.md
+++ b/docs/projects/11/design.md
@@ -1,0 +1,82 @@
+# #11 — Extended Thinking / Reasoning Content Preservation
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/11
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+OpenRouter config supports `reasoning` effort level (`none | low | medium | high`), but reasoning content from model responses is discarded. Not stored in conversation history, not available for compaction or debugging.
+
+## Design
+
+### Approach: Field on Message (Option A)
+
+Add `reasoning_content?: string` directly to the `Message` type. This is metadata that most consumers can ignore. The `Message` type is internal, not an API contract.
+
+### Model Response
+
+Add `reasoning_content?: string` to `ModelResponse` in `src/model/types.ts`. Each provider extracts it from the raw API response.
+
+### Provider Changes
+
+**`src/model/anthropic.ts`**
+- Claude returns thinking as `thinking` content blocks in the response
+- Concatenate all `thinking` block text into a single `reasoning_content` string
+- Set on the `ModelResponse`
+
+**`src/model/openrouter.ts`**
+- OpenRouter surfaces reasoning in response metadata (varies by underlying model)
+- Extract from the response if present
+
+**`src/model/openai-compat.ts`**
+- o1-style models may include reasoning tokens
+- Extract if present in the response structure
+
+**`src/model/ollama.ts`**
+- Local models don't emit reasoning content
+- No-op — leave `reasoning_content` undefined
+
+**`src/model/lemonade.ts`** (if separate from openai-compat)
+- Same treatment as openai-compat — extract reasoning if present in the response
+- Lemonade is an OpenAI-compat variant, so the extraction logic should mirror that provider
+
+### Agent Loop
+
+In `src/agent/agent.ts`, after building `assistantMessage` (line ~177):
+- Check `response.reasoning_content`
+- If present, attach to the message: `assistantMessage.reasoning_content = response.reasoning_content`
+
+### Compaction
+
+In `src/agent/compaction.ts` `formatConversation()`:
+- When serializing assistant messages, include reasoning content if present
+- Format as: `### assistant (reasoning)\n{reasoning_content}\n### assistant\n{content}`
+- This lets the summarizer see why decisions were made
+
+### Message Serialization
+
+In `src/agent/messages.ts`:
+- When serializing messages to/from store, preserve the `reasoning_content` field
+- JSON serialization handles this naturally if the field exists
+
+## Files Touched
+
+- `src/model/types.ts` — add `reasoning_content?: string` to `ModelResponse` and `Message`
+- `src/model/anthropic.ts` — extract from thinking blocks
+- `src/model/openrouter.ts` — extract from response metadata
+- `src/model/openai-compat.ts` — extract if present (covers lemonade)
+- `src/model/ollama.ts` — no-op (verify no crash if field absent)
+- `src/agent/agent.ts` — attach reasoning to assistant message
+- `src/agent/compaction.ts` — include reasoning in formatted conversation
+
+## Acceptance Criteria
+
+1. `ModelResponse` has optional `reasoning_content` field
+2. `Message` has optional `reasoning_content` field
+3. Anthropic provider extracts thinking blocks into `reasoning_content`
+4. OpenRouter provider extracts reasoning metadata
+5. OpenAI-compat / lemonade providers extract reasoning if present
+6. Agent loop attaches reasoning to assistant messages in history
+7. Compaction serializer includes reasoning content when formatting
+8. No display in TUI (preserved in data only)
+9. Test: mock model response with reasoning → verify stored on assistant message in history

--- a/docs/projects/11/implementation-plan/phase_01.md
+++ b/docs/projects/11/implementation-plan/phase_01.md
@@ -1,0 +1,108 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 1
+
+**Goal:** Add the `reasoning_content` optional field to `ModelResponse` and `Message` types so providers can surface reasoning and the agent loop can propagate it.
+
+**Architecture:** A single optional string field on both the response type (provider output) and the message type (conversation history). Consumers that don't care about reasoning ignore the field. No schema migrations needed — messages are serialized as JSON strings in SQLite and the field survives naturally.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime
+
+**Scope:** 3 phases total (this is phase 1 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC1: ModelResponse has optional reasoning_content field
+- **GH11.AC1.1 Success:** `ModelResponse` type includes `reasoning_content?: string`
+
+### GH11.AC2: Message has optional reasoning_content field
+- **GH11.AC2.1 Success:** `Message` type includes `reasoning_content?: string`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `reasoning_content` to `ModelResponse`
+
+**Verifies:** GH11.AC1.1
+
+**Files:**
+- Modify: `src/model/types.ts:59-63`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `ModelResponse` type. This is the provider-facing output — each provider sets it when reasoning content is present in the API response.
+
+In `src/model/types.ts`, the current `ModelResponse` type (lines 59-63) is:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+};
+```
+
+Add the field:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The field is optional so all existing provider return sites remain valid.
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add `reasoning_content` to `Message`
+
+**Verifies:** GH11.AC2.1
+
+**Files:**
+- Modify: `src/model/types.ts:35-38`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `Message` type. This is the conversation history type — the agent loop attaches reasoning content to assistant messages so it persists across the session.
+
+The current `Message` type (lines 35-38) is:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+};
+```
+
+Add the field:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. All existing message construction sites pass because the field is optional.
+
+**Commit:** `feat(types): add reasoning_content field to ModelResponse and Message`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/11/implementation-plan/phase_02.md
+++ b/docs/projects/11/implementation-plan/phase_02.md
@@ -1,0 +1,257 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 2
+
+**Goal:** Extract reasoning content from each model provider's API response and set it on the `ModelResponse`.
+
+**Architecture:** Each provider has a different response format for reasoning. Anthropic returns `thinking` content blocks. OpenRouter surfaces a `reasoning` string on the assistant message. OpenAI-compat may include reasoning in the response (o1-style models). Ollama does not emit reasoning — no-op. Each provider extracts and concatenates reasoning text into the single `reasoning_content` string field added in Phase 1.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, `@anthropic-ai/sdk` (v0.39+), `@openrouter/sdk` (v0.12+)
+
+**Scope:** 3 phases total (this is phase 2 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC3: Anthropic provider extracts thinking blocks into reasoning_content
+- **GH11.AC3.1 Success:** When Claude returns `thinking` content blocks, they are concatenated into `reasoning_content` on the `ModelResponse`
+- **GH11.AC3.2 No-op:** When no thinking blocks are present, `reasoning_content` is `undefined`
+
+### GH11.AC4: OpenRouter provider extracts reasoning metadata
+- **GH11.AC4.1 Success:** When OpenRouter response includes `reasoning` on the assistant message, it is set as `reasoning_content`
+- **GH11.AC4.2 No-op:** When `reasoning` is absent/null, `reasoning_content` is `undefined`
+
+### GH11.AC5: OpenAI-compat / lemonade providers extract reasoning if present
+- **GH11.AC5.1 Success:** When response includes a `reasoning_content` field on the message, it is extracted
+- **GH11.AC5.2 No-op:** When field is absent, `reasoning_content` is `undefined`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Anthropic provider — extract thinking blocks
+
+**Verifies:** GH11.AC3.1, GH11.AC3.2
+
+**Files:**
+- Modify: `src/model/anthropic.ts:23-37` (mapContentBlock function)
+- Modify: `src/model/anthropic.ts:70-89` (complete function, response mapping + return)
+
+**Implementation:**
+
+The Anthropic SDK's `ContentBlock` union already includes `ThinkingBlock` (`{ type: 'thinking'; thinking: string; signature: string }`) and `RedactedThinkingBlock` (`{ type: 'redacted_thinking' }`). The current `mapContentBlock` function has a fallback for unknown block types but does not handle `thinking` explicitly.
+
+Two changes needed:
+
+**1. Update `mapContentBlock` to skip thinking blocks.**
+
+Thinking blocks should not be mapped into the agent's `ContentBlock[]` — they are metadata, not content the agent acts on. The function currently falls through to a text fallback for unknown types. Add an explicit case that returns `null` for thinking blocks, and filter nulls from the result.
+
+Replace the current `mapContentBlock` and the line that calls it:
+
+```typescript
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
+  if (block.type === 'text') {
+    return { type: 'text', text: block.text };
+  }
+  if (block.type === 'tool_use') {
+    return {
+      type: 'tool_use',
+      id: block.id,
+      name: block.name,
+      input: block.input as Record<string, unknown>,
+    };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
+  }
+  // Fallback: treat unknown block types as text
+  return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
+}
+```
+
+Update the content mapping in `complete()` (currently line 74):
+
+```typescript
+const content: Array<ContentBlock> = response.content
+  .map(mapContentBlock)
+  .filter((b): b is ContentBlock => b !== null);
+```
+
+**2. Extract reasoning content from thinking blocks.**
+
+After the content mapping, concatenate all `thinking` block text into `reasoning_content`:
+
+```typescript
+const thinkingTexts = response.content
+  .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+  .map((b) => b.thinking);
+const reasoning_content = thinkingTexts.length > 0
+  ? thinkingTexts.join('\n\n')
+  : undefined;
+```
+
+Then include it in the return:
+
+```typescript
+return {
+  content,
+  stop_reason: mapStopReason(response.stop_reason),
+  usage: {
+    input_tokens: response.usage.input_tokens,
+    output_tokens: response.usage.output_tokens,
+    cache_creation_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_creation_input_tokens'] as
+        number | null | undefined ?? null,
+    cache_read_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
+        number | null | undefined ?? null,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(anthropic): extract thinking blocks into reasoning_content`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: OpenRouter provider — extract reasoning field
+
+**Verifies:** GH11.AC4.1, GH11.AC4.2
+
+**Files:**
+- Modify: `src/model/openrouter.ts:223-237` (return statement in complete function)
+
+**Implementation:**
+
+The OpenRouter SDK's `ChatAssistantMessage` type includes `reasoning?: string | null | undefined`. The current code accesses `choice.message` but does not read `reasoning`.
+
+After the existing debug log line (line 228), extract the reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+  ? choice.message.reasoning
+  : undefined;
+```
+
+Then include it in the return object (currently lines 230-237):
+
+```typescript
+return {
+  content: mapResponseContent(choice.message),
+  stop_reason: mapFinishReason(choice.finishReason),
+  usage: {
+    input_tokens: response.usage?.promptTokens ?? 0,
+    output_tokens: response.usage?.completionTokens ?? 0,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openrouter): extract reasoning into reasoning_content`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: OpenAI-compat provider — extract reasoning if present
+
+**Verifies:** GH11.AC5.1, GH11.AC5.2
+
+**Files:**
+- Modify: `src/model/openai-compat.ts:34-45` (OpenAIChoice type)
+- Modify: `src/model/openai-compat.ts:270-281` (return statement in complete function)
+
+**Implementation:**
+
+Some OpenAI-compatible providers (e.g., o1-style models, DeepSeek-R1 via compatible endpoints) return reasoning in the response. The field name varies but the most common convention is `reasoning_content` on the message object. The current `OpenAIChoice` type does not include this field.
+
+**1. Extend the `OpenAIChoice` type** to accept an optional reasoning field on the message:
+
+```typescript
+type OpenAIChoice = {
+  message: {
+    role: 'assistant';
+    content: string | null;
+    reasoning_content?: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }>;
+  };
+  finish_reason: string;
+};
+```
+
+**2. Extract reasoning in the return.** After getting `choice` (line 272), extract reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+  ? choice.message.reasoning_content
+  : undefined;
+```
+
+Include in the return:
+
+```typescript
+return {
+  content: mapResponseContent(choice),
+  stop_reason: mapFinishReason(choice.finish_reason),
+  usage: {
+    input_tokens: data.usage.prompt_tokens,
+    output_tokens: data.usage.completion_tokens,
+  },
+  reasoning_content,
+};
+```
+
+**Note:** This also covers the `lemonade` provider case from the design — there is no separate `src/model/lemonade.ts` file. Lemonade uses the OpenAI-compat provider, so this change covers both.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openai-compat): extract reasoning_content from response`
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Ollama provider — verify no-op
+
+**Verifies:** None (verification that existing provider doesn't crash with the new optional field)
+
+**Files:**
+- No modifications to `src/model/ollama.ts`
+
+**Implementation:**
+
+No code changes. The Ollama provider's `complete()` method returns a `ModelResponse` without `reasoning_content`, which is valid because the field is optional. Local models served by Ollama do not emit reasoning content.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The Ollama provider compiles cleanly without setting `reasoning_content` because the field is optional on `ModelResponse`.
+
+No commit needed for this task — it's a verification step only.
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/phase_03.md
+++ b/docs/projects/11/implementation-plan/phase_03.md
@@ -1,0 +1,308 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 3
+
+**Goal:** Wire reasoning content through the agent loop (attach to assistant messages in history), include it in compaction serialization, and add a test proving the end-to-end flow.
+
+**Architecture:** The agent loop in `agent.ts` builds an `assistantMessage` from the model response. We attach `reasoning_content` from the response to the message. The compaction serializer in `compaction.ts` already formats messages into markdown — we prepend reasoning content as a separate section when present. A new test file verifies the full flow: mock model returns reasoning, verify it lands on the history message and appears in compaction output.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, Bun test runner
+
+**Scope:** 3 phases total (this is phase 3 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH11.AC6: Agent loop attaches reasoning to assistant messages in history
+- **GH11.AC6.1 Success:** When `response.reasoning_content` is present, it is set on the assistant message pushed to history
+- **GH11.AC6.2 No-op:** When `response.reasoning_content` is undefined, the message has no `reasoning_content` field
+
+### GH11.AC7: Compaction serializer includes reasoning content when formatting
+- **GH11.AC7.1 Success:** When an assistant message has `reasoning_content`, `formatConversation()` includes it in the output as `### assistant (reasoning)\n{reasoning_content}` before the main `### assistant\n{content}` block
+- **GH11.AC7.2 No-op:** When no `reasoning_content` is present, formatting is unchanged
+
+### GH11.AC8: No display in TUI (preserved in data only)
+- **GH11.AC8.1 Verification:** No changes to any TUI component. Reasoning content exists only on the `Message` type and in compaction output.
+
+### GH11.AC9: Test — mock model response with reasoning, verify stored on assistant message
+- **GH11.AC9.1 Success:** A test with a mock model returning `reasoning_content` verifies the field appears on the assistant message in history
+- **GH11.AC9.2 Success:** A test verifies `formatConversation()` includes reasoning in the serialized output
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Agent loop — attach reasoning to assistant message
+
+**Verifies:** GH11.AC6.1, GH11.AC6.2
+
+**Files:**
+- Modify: `src/agent/agent.ts:177` (assistant message construction)
+
+**Implementation:**
+
+In `_chatImpl`, after the model call, the assistant message is constructed at line 177:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+```
+
+Add reasoning content propagation immediately after this line:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+if (response.reasoning_content) {
+  assistantMessage.reasoning_content = response.reasoning_content;
+}
+```
+
+This is a simple conditional assignment. When `reasoning_content` is undefined (the common case for most models), nothing happens. When present (e.g., Anthropic thinking blocks, OpenRouter reasoning), it's preserved on the message in history.
+
+**Note on TUI (GH11.AC8):** No TUI files need changes. The `ChatResult` type returned by `chat()` contains only `text` and `stats` — reasoning content is preserved in the internal `history` array and in compaction output, but never surfaced to the UI layer.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(agent): attach reasoning_content to assistant messages in history`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Compaction — include reasoning in formatted conversation
+
+**Verifies:** GH11.AC7.1, GH11.AC7.2
+
+**Files:**
+- Modify: `src/agent/compaction.ts:19-37` (formatConversation function)
+
+**Implementation:**
+
+The `formatConversation` function serializes messages into markdown for context compaction. Currently it formats each message as `### {role}\n{content}`. When an assistant message has `reasoning_content`, we should include it so the summarizer can see the model's reasoning chain.
+
+The current function (lines 19-37):
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+      return `### ${msg.role}\n${content}`;
+    })
+    .join('\n\n');
+}
+```
+
+Replace it with:
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
+    })
+    .join('\n\n');
+}
+```
+
+When `reasoning_content` is present, the output for that message becomes:
+
+```
+### assistant (reasoning)
+{reasoning text here}
+
+### assistant
+{actual response content}
+```
+
+When absent, output is identical to the previous format: `### assistant\n{content}`.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(compaction): include reasoning_content in formatted conversation`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: Test — reasoning content flows through agent loop
+
+**Verifies:** GH11.AC9.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Implementation:**
+
+Create a test that exercises the agent loop with a mock model that returns `reasoning_content`. The test verifies that the reasoning appears on the assistant message in history.
+
+The test needs to mock several dependencies:
+- `ModelProvider` — returns a `ModelResponse` with `reasoning_content` and `stop_reason: 'end_turn'`
+- `CodeRuntime` — not needed (model stops on first call, no tool use)
+- `Store` — minimal mock that returns empty docs
+- `personaPath` — points to a temp file with a basic persona
+
+Key behavior to test:
+- Call `agent.chat("test")` with a model mock that returns `reasoning_content: "I thought about this carefully"`
+- The agent's internal history is not directly exposed, but we can verify via a second call: override conversation with the history from a captured mock
+- Alternatively, since `createAgent` doesn't expose history, test the `formatConversation` integration path instead (see Task 4)
+
+A more direct approach: since the agent returns `ChatResult` with only `text` and `stats`, and reasoning is preserved internally, the most valuable test is to verify that a model response with reasoning doesn't break the agent loop and that the text response is correctly extracted. The reasoning preservation is structural (type system enforces it once the field is set).
+
+However, for a proper behavioral test, we can use `conversationOverride` to inject a message with reasoning and verify the model receives it back on subsequent calls. Here's the approach:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+
+// Track what the model receives so we can inspect history
+const receivedMessages: Message[][] = [];
+
+const mockModel = {
+  async complete(request: { messages: ReadonlyArray<Message> }): Promise<ModelResponse> {
+    receivedMessages.push([...request.messages]);
+    return {
+      content: [{ type: 'text', text: 'I have responded.' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 5 },
+      reasoning_content: 'Let me think step by step about this problem.',
+    };
+  },
+};
+```
+
+The full test creates an agent with minimal mocks, calls `chat()`, then calls `chat()` again and inspects the messages sent to the model on the second call. The second call's messages should include the assistant message from the first call, which should have `reasoning_content` set.
+
+**Testing pattern notes:**
+- Bun test runner is used (`bun test`)
+- No existing test files in the codebase, so this establishes the pattern
+- The persona file must exist — use `Bun.write` to create a temp file
+- Store mock needs `docGet`, `docList` methods minimum (used by `loadCoreMemoryFromStore` and skill listing)
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/agent.test.ts`
+Expected: Test passes.
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Test — formatConversation includes reasoning
+
+**Verifies:** GH11.AC9.2
+
+**Files:**
+- Create: `src/agent/compaction.test.ts`
+
+**Implementation:**
+
+Test the `formatConversation` function directly. This is a pure function — much easier to test in isolation than the full agent loop.
+
+Problem: `formatConversation` is not exported (it's a module-private function in `compaction.ts`). Two options:
+
+**Option A (preferred):** Export `formatConversation` from `compaction.ts`. It's a pure function with no side effects — there's no reason to hide it, and exporting it enables direct testing.
+
+**Option B:** Test indirectly through `compactContext`, which is exported but requires store + model mocks.
+
+Go with Option A. Add `export` to `formatConversation`:
+
+In `src/agent/compaction.ts`, change line 19 from:
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+to:
+```typescript
+export function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+
+Then create the test:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/compaction.test.ts`
+Expected: Both tests pass.
+
+**Commit:** `test(GH11): add tests for reasoning_content in agent loop and compaction`
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/test-requirements.md
+++ b/docs/projects/11/implementation-plan/test-requirements.md
@@ -1,0 +1,51 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+### Automated Tests
+
+| AC | Description | Test Type | Test File | Notes |
+|----|-------------|-----------|-----------|-------|
+| GH11.AC1.1 | `ModelResponse` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler (`tsc --noEmit`). No runtime test needed. |
+| GH11.AC2.1 | `Message` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler. No runtime test needed. |
+| GH11.AC3.1 | Anthropic extracts thinking blocks | Type check | N/A | Structural — verified by compiler. Integration testing requires live Anthropic API with extended thinking enabled. |
+| GH11.AC3.2 | Anthropic no-op when no thinking blocks | Type check | N/A | Field is optional, absence is the default. Compiler verifies. |
+| GH11.AC4.1 | OpenRouter extracts reasoning | Type check | N/A | Structural — verified by compiler. Integration testing requires live OpenRouter API with reasoning model. |
+| GH11.AC4.2 | OpenRouter no-op when no reasoning | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC5.1 | OpenAI-compat extracts reasoning_content | Type check | N/A | Structural — verified by compiler. |
+| GH11.AC5.2 | OpenAI-compat no-op when absent | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC6.1 | Agent loop attaches reasoning to assistant message | Unit | `src/agent/agent.test.ts` | Mock model returns reasoning, verify it appears in history on next model call. |
+| GH11.AC6.2 | Agent loop no-op when reasoning absent | Unit | `src/agent/agent.test.ts` | Mock model returns no reasoning, verify message has no `reasoning_content`. |
+| GH11.AC7.1 | Compaction includes reasoning in formatted output | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` with a message containing `reasoning_content`. |
+| GH11.AC7.2 | Compaction unchanged when no reasoning | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` without `reasoning_content` — output matches prior format. |
+| GH11.AC9.1 | Test: mock model with reasoning, verify on assistant message | Unit | `src/agent/agent.test.ts` | Core behavioral test of the feature. |
+| GH11.AC9.2 | Test: formatConversation includes reasoning | Unit | `src/agent/compaction.test.ts` | Core behavioral test of compaction serialization. |
+
+### Human Verification
+
+| AC | Description | Verification Approach |
+|----|-------------|----------------------|
+| GH11.AC8.1 | No display in TUI | Verify no TUI files were modified. Run `git diff --name-only` after implementation and confirm no files under `src/tui/` appear. |
+| GH11.AC3.1 (integration) | Anthropic thinking blocks extracted in production | Manually test with a Claude model that supports extended thinking. Set `reasoning: high` in config, send a request, inspect debug logs for reasoning content. |
+| GH11.AC4.1 (integration) | OpenRouter reasoning extracted in production | Manually test with an OpenRouter model that returns reasoning. Inspect debug logs. |
+
+## Test Execution
+
+```bash
+# Run all tests
+cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test
+
+# Run specific test files
+bun test src/agent/agent.test.ts
+bun test src/agent/compaction.test.ts
+
+# Type checking (covers AC1-AC5 structurally)
+npx tsc --noEmit
+```
+
+## Summary
+
+- **4 automated unit tests** across 2 test files
+- **Type checking** covers the structural correctness of all provider changes (AC1-AC5)
+- **3 human verification items** for TUI non-impact and live integration testing
+- Provider extraction logic (AC3-AC5) is structural — the code either sets the field from the API response or doesn't. The extraction patterns are straightforward conditional reads with no branching logic that warrants mocking the HTTP layer.

--- a/docs/projects/14/design.md
+++ b/docs/projects/14/design.md
@@ -1,0 +1,44 @@
+# #14 — Standalone Secrets Management
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/14
+**Wave:** 0 (no dependencies)
+**Status:** Mostly complete — extending existing implementation
+
+## Current State
+
+`src/secrets/manager.ts` already implements the full `SecretManager` interface:
+- `listKeys()` — sorted array of secret names (never values)
+- `get(key)` — returns value (internal use only — env injection)
+- `set(key, value)` — create/update + persist
+- `remove(key)` — delete + persist
+- `resolve(keys)` — bulk resolve to env var map
+
+Storage: `data/secrets.json` (flat JSON key-value pairs). Already wired into `src/index.ts` and passed to agents via `AgentDependencies`.
+
+## Design
+
+### Change: Make persistence awaitable
+
+Currently `set()` and `remove()` call an internal `save()` that is fire-and-forget (`writeFile` with `.catch(() => {})`). New consumers (TUI secrets screen, custom tools) need to know when persistence completes.
+
+**Change `set()` and `remove()` signatures to return `Promise<void>`.**
+
+Internally, replace the fire-and-forget `save()` with a direct `await writeFile(...)`. The `mkdir` call stays (ensures `data/` exists on first write).
+
+### No other changes needed
+
+- Type is already exported from `src/secrets/index.ts`
+- Already usable by new consumers (web tools, notify tool, custom tools will call `deps.secrets?.get('KEY_NAME')`)
+- TUI secrets screen is #13's responsibility
+
+## Files Touched
+
+- `src/secrets/manager.ts` — make `set`/`remove` return `Promise<void>`
+- New test file for integration test (set/get/remove/resolve, verify JSON on disk)
+
+## Acceptance Criteria
+
+1. `set()` and `remove()` return `Promise<void>`
+2. After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }`
+3. `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys)
+4. Existing callers unaffected (returned promise can be ignored for backward compat)

--- a/docs/projects/14/implementation-plan/phase_01.md
+++ b/docs/projects/14/implementation-plan/phase_01.md
@@ -1,0 +1,306 @@
+# GH14: Standalone Secrets Management — Implementation Plan
+
+**Goal:** Make `SecretManager.set()` and `remove()` return `Promise<void>` so callers can await persistence, and add integration tests verifying the full lifecycle.
+
+**Architecture:** Minimal change to the existing `SecretManager` closure in `src/secrets/manager.ts`. The internal `save()` function becomes async and is awaited by `set()` and `remove()`. The type definition updates accordingly. Existing callers that ignore the return value remain unaffected (returning a `Promise<void>` where `void` was returned before is backward-compatible in TypeScript).
+
+**Tech Stack:** Bun (runtime + test runner), `node:fs/promises`
+
+**Scope:** 1 phase from original design (phase 1 of 1)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH14.AC1: Awaitable persistence
+- **GH14.AC1.1 Success:** `set()` and `remove()` return `Promise<void>`
+
+### GH14.AC2: Persistence correctness
+- **GH14.AC2.1 Success:** After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }`
+
+### GH14.AC3: Resolve behaviour
+- **GH14.AC3.1 Success:** `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys)
+
+### GH14.AC4: Backward compatibility
+- **GH14.AC4.1 Success:** Existing callers unaffected (returned promise can be ignored for backward compat)
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Update `SecretManager` type and implementation for awaitable persistence
+
+**Verifies:** GH14.AC1.1, GH14.AC4.1
+
+**Files:**
+- Modify: `src/secrets/manager.ts`
+
+**Implementation:**
+
+Two changes to `src/secrets/manager.ts`:
+
+**Change 1: Update the `SecretManager` type (lines 17, 19)**
+
+Replace the current synchronous signatures:
+
+```typescript
+/** Set a secret. */
+set(key: string, value: string): void;
+/** Delete a secret. */
+remove(key: string): void;
+```
+
+With async signatures:
+
+```typescript
+/** Set a secret. Resolves when persisted to disk. */
+set(key: string, value: string): Promise<void>;
+/** Delete a secret. Resolves when persisted to disk. */
+remove(key: string): Promise<void>;
+```
+
+**Change 2: Make `save()` awaitable and `set()`/`remove()` async (lines 40-62)**
+
+Replace the current fire-and-forget `save()` and the `set()`/`remove()` methods:
+
+```typescript
+// Current (fire-and-forget):
+function save(): void {
+  mkdir(dirname(path), { recursive: true })
+    .then(() => writeFile(path, JSON.stringify(secrets, null, 2) + '\n'))
+    .catch(() => {});
+}
+
+// ...
+set(key: string, value: string): void {
+  secrets[key] = value;
+  save();
+},
+
+remove(key: string): void {
+  delete secrets[key];
+  save();
+},
+```
+
+With:
+
+```typescript
+async function save(): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(secrets, null, 2) + '\n');
+}
+
+// ...
+async set(key: string, value: string): Promise<void> {
+  secrets[key] = value;
+  await save();
+},
+
+async remove(key: string): Promise<void> {
+  delete secrets[key];
+  await save();
+},
+```
+
+Note: error handling is intentionally removed from `save()`. The design specifies that callers should now see errors rather than swallowing them. If `writeFile` fails, the promise rejects and the caller gets the error. The in-memory state is still updated (consistent with prior behaviour where the in-memory update succeeded even if save failed).
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Builds without errors. The existing callers in `src/tui/ReviewPage.tsx` (lines 170, 195) call `secrets.set()` and `secrets.remove()` without `await` — this is valid TypeScript since ignoring a `Promise<void>` return is permitted.
+
+**Commit:** `feat(secrets): make set() and remove() return Promise<void> for awaitable persistence`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add integration tests for SecretManager lifecycle
+
+**Verifies:** GH14.AC1.1, GH14.AC2.1, GH14.AC3.1, GH14.AC4.1
+
+**Files:**
+- Create: `src/secrets/manager.test.ts`
+
+**Implementation:**
+
+This is the first test file in the project. Uses Bun's built-in test runner (`bun test`), which auto-discovers `*.test.ts` files. Bun's test API uses `describe`, `test`/`it`, and `expect` — no imports needed for these globals (they're injected by the Bun test runner).
+
+Create `src/secrets/manager.test.ts` with these test cases:
+
+```typescript
+// Integration tests for SecretManager — verifies persistence lifecycle against real filesystem.
+
+import { readFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSecretManager } from './manager.ts';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+const TEST_DIR = join(import.meta.dir, '../../.test-tmp');
+const TEST_PATH = join(TEST_DIR, 'secrets.json');
+
+function cleanup(): void {
+  try {
+    rmSync(TEST_DIR, { recursive: true });
+  } catch {
+    // ignore if doesn't exist
+  }
+}
+
+describe('SecretManager', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  test('set() persists to JSON file on disk', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ FOO: 'bar' });
+  });
+
+  test('set() returns a Promise', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const result = mgr.set('X', 'Y');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('remove() returns a Promise', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('X', 'Y');
+    const result = mgr.remove('X');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('get() retrieves a previously set value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('TOKEN', 'abc123');
+    expect(mgr.get('TOKEN')).toBe('abc123');
+  });
+
+  test('get() returns undefined for missing keys', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    expect(mgr.get('NONEXISTENT')).toBeUndefined();
+  });
+
+  test('remove() deletes a secret and persists', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('DEL_ME', 'gone');
+    await mgr.remove('DEL_ME');
+
+    expect(mgr.get('DEL_ME')).toBeUndefined();
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({});
+  });
+
+  test('listKeys() returns sorted key names', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('ZEBRA', 'z');
+    await mgr.set('ALPHA', 'a');
+    await mgr.set('MIDDLE', 'm');
+
+    expect(mgr.listKeys()).toEqual(['ALPHA', 'MIDDLE', 'ZEBRA']);
+  });
+
+  test('resolve() returns env map for existing keys, skips missing', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+    await mgr.set('BAZ', 'qux');
+
+    const env = mgr.resolve(['FOO', 'MISSING', 'BAZ']);
+    expect(env).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('resolve() returns empty object when no keys match', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const env = mgr.resolve(['NOTHING', 'NOPE']);
+    expect(env).toEqual({});
+  });
+
+  test('new manager loads persisted secrets from disk', async () => {
+    const mgr1 = createSecretManager(TEST_PATH);
+    await mgr1.set('PERSIST', 'across-instances');
+
+    const mgr2 = createSecretManager(TEST_PATH);
+    expect(mgr2.get('PERSIST')).toBe('across-instances');
+    expect(mgr2.listKeys()).toEqual(['PERSIST']);
+  });
+
+  test('set() overwrites existing value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('KEY', 'old');
+    await mgr.set('KEY', 'new');
+
+    expect(mgr.get('KEY')).toBe('new');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ KEY: 'new' });
+  });
+
+  test('creates parent directory if it does not exist', async () => {
+    const nested = join(TEST_DIR, 'deep', 'nested', 'secrets.json');
+    const mgr = createSecretManager(nested);
+    await mgr.set('DEEP', 'value');
+
+    const raw = readFileSync(nested, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ DEEP: 'value' });
+  });
+
+  test('ignoring returned promise does not throw (backward compat)', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    // Existing callers call set()/remove() without await — this must not throw
+    mgr.set('IGNORED', 'promise');
+    mgr.remove('IGNORED');
+    // If we get here without error, backward compat is satisfied
+  });
+});
+```
+
+**Testing:**
+
+Tests verify each AC:
+- **GH14.AC1.1:** `set()` and `remove()` return `Promise` instances (tested via `toBeInstanceOf(Promise)`)
+- **GH14.AC2.1:** After `await mgr.set('FOO', 'bar')`, reading the file shows `{ FOO: 'bar' }` (tested via `readFileSync` + `JSON.parse`)
+- **GH14.AC3.1:** `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` — skips missing keys (tested directly)
+- **GH14.AC4.1:** Calling `set()`/`remove()` without `await` does not throw (backward compat test)
+
+**Verification:**
+
+Run: `bun test`
+Expected: All tests pass. Output shows discovered `src/secrets/manager.test.ts`.
+
+**Commit:** `test(secrets): add integration tests for SecretManager lifecycle`
+
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Verify build and full test suite
+
+**Files:**
+- None (verification only)
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Builds without errors.
+
+Run: `bun test`
+Expected: All tests pass.
+
+Verify backward compatibility by inspection: confirm that `src/tui/ReviewPage.tsx` still compiles (it calls `secrets.set()` and `secrets.remove()` without `await` at lines 195 and 170 respectively — this is valid because the promise is simply discarded).
+
+**Commit:** No commit needed — this is a verification step.
+
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/14/implementation-plan/test-requirements.md
+++ b/docs/projects/14/implementation-plan/test-requirements.md
@@ -1,0 +1,43 @@
+# GH14: Standalone Secrets Management — Test Requirements
+
+Maps each acceptance criterion to automated tests or human verification.
+
+---
+
+## Automated Tests
+
+All acceptance criteria for GH14 are verifiable via automated tests.
+
+| Criterion | Description | Test Type | Test File | Test Name(s) |
+|-----------|-------------|-----------|-----------|---------------|
+| GH14.AC1.1 | `set()` and `remove()` return `Promise<void>` | Unit | `src/secrets/manager.test.ts` | `set() returns a Promise`, `remove() returns a Promise` |
+| GH14.AC2.1 | After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }` | Integration | `src/secrets/manager.test.ts` | `set() persists to JSON file on disk` |
+| GH14.AC3.1 | `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys) | Unit | `src/secrets/manager.test.ts` | `resolve() returns env map for existing keys, skips missing` |
+| GH14.AC4.1 | Existing callers unaffected (returned promise can be ignored) | Unit | `src/secrets/manager.test.ts` | `ignoring returned promise does not throw (backward compat)` |
+
+## Additional Coverage
+
+These tests go beyond the minimum acceptance criteria to ensure robustness:
+
+| Behaviour | Test File | Test Name |
+|-----------|-----------|-----------|
+| `get()` retrieves set values | `src/secrets/manager.test.ts` | `get() retrieves a previously set value` |
+| `get()` returns undefined for missing keys | `src/secrets/manager.test.ts` | `get() returns undefined for missing keys` |
+| `remove()` deletes and persists | `src/secrets/manager.test.ts` | `remove() deletes a secret and persists` |
+| `listKeys()` returns sorted names | `src/secrets/manager.test.ts` | `listKeys() returns sorted key names` |
+| `resolve()` returns empty for no matches | `src/secrets/manager.test.ts` | `resolve() returns empty object when no keys match` |
+| New instance loads persisted data | `src/secrets/manager.test.ts` | `new manager loads persisted secrets from disk` |
+| `set()` overwrites existing values | `src/secrets/manager.test.ts` | `set() overwrites existing value` |
+| Parent directory auto-created | `src/secrets/manager.test.ts` | `creates parent directory if it does not exist` |
+
+## Human Verification
+
+| Criterion | Verification Approach | Justification |
+|-----------|----------------------|---------------|
+| GH14.AC4.1 | Verify `src/tui/ReviewPage.tsx` compiles — lines 170 and 195 call `secrets.remove()` / `secrets.set()` without `await` | TypeScript build confirms type compatibility, but human should confirm no runtime warnings in TUI usage |
+
+## Test Infrastructure Notes
+
+- This is the first test file in the project. Uses Bun's built-in test runner.
+- Tests use a temp directory (`.test-tmp/` relative to project root) cleaned up in `beforeEach`/`afterEach`.
+- All tests are integration tests against the real filesystem — no mocks needed since `SecretManager` is a thin wrapper around `fs`.

--- a/docs/projects/2/design.md
+++ b/docs/projects/2/design.md
@@ -1,0 +1,100 @@
+# #2 — Event Emission / Lifecycle Hooks
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/2
+**Wave:** 1 (no hard dependencies)
+
+## Current State
+
+`chat()` is a black box. Callers await it and get `ChatResult`. No visibility into what's happening mid-loop — TUI shows a generic "Thinking..." spinner with no granularity.
+
+## Design
+
+### Event Types
+
+In `src/agent/types.ts`:
+
+```typescript
+type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+
+type AgentEvent = {
+  readonly kind: AgentEventKind;
+  readonly data: Record<string, unknown>;
+};
+```
+
+### Callback on ChatOptions
+
+Add to `ChatOptions`:
+
+```typescript
+type ChatOptions = {
+  readonly context?: ChatContext;
+  readonly images?: ChatImage[];
+  readonly conversationOverride?: Array<Message>;
+  readonly onEvent?: (event: AgentEvent) => Promise<void>;
+};
+```
+
+### Emit Helper
+
+In `_chatImpl`, create a local helper:
+
+```typescript
+const emit = async (kind: AgentEventKind, data: Record<string, unknown>): Promise<void> => {
+  if (!options?.onEvent) return;
+  try {
+    await options.onEvent({ kind, data });
+  } catch (err) {
+    process.stderr.write(`[agent] event callback error (${kind}): ${err}\n`);
+  }
+};
+```
+
+Events are **awaited** so the UI can update synchronously before the next step. If the callback throws, log and continue — events never kill the agent loop.
+
+### Emit Points
+
+Four points in the tool loop:
+
+1. **Before `model.complete()`:**
+   ```
+   await emit('llm_start', { round });
+   ```
+
+2. **After `model.complete()`:**
+   ```
+   await emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason });
+   ```
+
+3. **Before `runtime.execute()`:**
+   ```
+   await emit('tool_start', { tool: 'execute_code', code: code.slice(0, 500) });
+   ```
+
+4. **After `runtime.execute()`:**
+   ```
+   await emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) });
+   ```
+
+### Also emit for the max-iteration final call (#1)
+
+If #1 is merged first, also emit `llm_start`/`llm_done` around the forced final response call.
+
+### Future: native tool events (#3)
+
+Once multi-tool architecture lands, `tool_start`/`tool_done` also fire for native tool calls. The `tool` field in `data` carries the tool name instead of `'execute_code'`. The interface is identical — no changes needed to the event types.
+
+## Files Touched
+
+- `src/agent/types.ts` — add `AgentEvent`, `AgentEventKind`, update `ChatOptions`
+- `src/agent/agent.ts` — add emit helper, four emit calls in tool loop
+
+## Acceptance Criteria
+
+1. `AgentEvent` and `AgentEventKind` types exported
+2. `onEvent` callback on `ChatOptions` is optional
+3. All four events fire in order: `llm_start` → `llm_done` → `tool_start` → `tool_done`
+4. Callback errors are logged, not thrown
+5. Code preview in `tool_start` truncated to 500 chars
+6. Result preview in `tool_done` truncated to 200 chars
+7. Test: provide `onEvent` callback, run chat with tool use, verify all four event kinds fire in correct order

--- a/docs/projects/2/implementation-plan/phase_01.md
+++ b/docs/projects/2/implementation-plan/phase_01.md
@@ -1,0 +1,132 @@
+# GH02: Event Emission / Lifecycle Hooks — Phase 1
+
+**Goal:** Define the event types and update ChatOptions so the agent loop can emit lifecycle events to callers.
+
+**Architecture:** Add `AgentEventKind` (string literal union) and `AgentEvent` (readonly typed object) to the Functional Core types module. Extend `ChatOptions` with an optional `onEvent` callback. Update the barrel export to expose the new types.
+
+**Tech Stack:** TypeScript (bun runtime, strict mode)
+
+**Scope:** 2 phases from original design (phase 1 of 2)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements types only. Tests for event emission behaviour are in Phase 2.
+
+### GH02.AC1: AgentEvent and AgentEventKind types exported
+- **GH02.AC1.1 Success:** `AgentEventKind` is a string literal union of `'llm_start' | 'llm_done' | 'tool_start' | 'tool_done'`
+- **GH02.AC1.2 Success:** `AgentEvent` is a readonly type with `kind: AgentEventKind` and `data: Record<string, unknown>`
+- **GH02.AC1.3 Success:** Both types are re-exported from `src/agent/index.ts`
+
+### GH02.AC2: onEvent callback on ChatOptions is optional
+- **GH02.AC2.1 Success:** `ChatOptions.onEvent` is typed as `((event: AgentEvent) => Promise<void>) | undefined`
+- **GH02.AC2.2 Success:** Existing callers that omit `onEvent` continue to compile with no changes
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add AgentEventKind and AgentEvent types
+
+**Verifies:** GH02.AC1.1, GH02.AC1.2
+
+**Files:**
+- Modify: `src/agent/types.ts` (append after line 66, before the closing of `ChatOptions`)
+
+**Implementation:**
+
+Add the following types immediately before the `ChatOptions` type definition (before line 62):
+
+```typescript
+export type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+
+export type AgentEvent = {
+  readonly kind: AgentEventKind;
+  readonly data: Record<string, unknown>;
+};
+```
+
+These are pure type declarations. `AgentEventKind` is a string literal union (not an enum, per house style). `AgentEvent` uses `readonly` fields to match the project's immutability convention.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bunx tsc --noEmit`
+Expected: No type errors (types are additive, no existing code is changed)
+
+**Commit:** `feat(agent): add AgentEventKind and AgentEvent types`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add onEvent to ChatOptions
+
+**Verifies:** GH02.AC2.1, GH02.AC2.2
+
+**Files:**
+- Modify: `src/agent/types.ts:62-66` (the `ChatOptions` type)
+
+**Implementation:**
+
+Update the `ChatOptions` type to include the optional `onEvent` callback:
+
+```typescript
+export type ChatOptions = {
+  readonly context?: ChatContext;
+  readonly images?: ChatImage[];
+  readonly conversationOverride?: Array<Message>;
+  readonly onEvent?: (event: AgentEvent) => Promise<void>;
+};
+```
+
+The field is optional (`?:`) so all existing callers (`src/tui/App.tsx:99`, `src/discord/bot.ts:189`, `src/scheduler/scheduler.ts:207`) continue to work without changes.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bunx tsc --noEmit`
+Expected: No type errors. Existing callers don't provide `onEvent` and compile cleanly.
+
+**Commit:** `feat(agent): add optional onEvent callback to ChatOptions`
+
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Update barrel export
+
+**Verifies:** GH02.AC1.3
+
+**Files:**
+- Modify: `src/agent/index.ts`
+
+**Implementation:**
+
+Add `AgentEvent` and `AgentEventKind` to the type re-export line. The current barrel export at `src/agent/index.ts` is:
+
+```typescript
+export type { Agent, AgentConfig, AgentDependencies, ConversationTurn } from './types.ts';
+```
+
+Update to:
+
+```typescript
+export type { Agent, AgentConfig, AgentDependencies, AgentEvent, AgentEventKind, ConversationTurn } from './types.ts';
+```
+
+Alphabetical order is maintained.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bunx tsc --noEmit`
+Expected: No type errors.
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bun run build`
+Expected: Build succeeds.
+
+**Commit:** `feat(agent): export AgentEvent and AgentEventKind from barrel`
+
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/2/implementation-plan/phase_02.md
+++ b/docs/projects/2/implementation-plan/phase_02.md
@@ -1,0 +1,186 @@
+# GH02: Event Emission / Lifecycle Hooks — Phase 2
+
+**Goal:** Wire the emit helper into the agent loop and add the four lifecycle event emission points, with an integration test proving correct ordering and error resilience.
+
+**Architecture:** Create a local `emit` helper inside `_chatImpl` that guards on `options?.onEvent`, catches callback errors, and logs to stderr. Insert four `await emit(...)` calls at the defined points in the tool loop. The test mocks `ModelProvider` and `CodeRuntime` to drive one full tool-use round and asserts all four events fire in order.
+
+**Tech Stack:** TypeScript (bun runtime, bun:test)
+
+**Scope:** 2 phases from original design (phase 2 of 2)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+### GH02.AC3: All four events fire in order
+- **GH02.AC3.1 Success:** Events fire in order `llm_start` -> `llm_done` -> `tool_start` -> `tool_done` during a tool-use round
+- **GH02.AC3.2 Success:** `llm_start` and `llm_done` also fire on the final `end_turn` round (no tool dispatch, so no `tool_start`/`tool_done`)
+
+### GH02.AC4: Callback errors are logged, not thrown
+- **GH02.AC4.1 Success:** If `onEvent` throws, the error is written to stderr and the agent loop continues
+- **GH02.AC4.2 Success:** The agent produces a normal `ChatResult` even when `onEvent` throws on every call
+
+### GH02.AC5: Code preview in tool_start truncated to 500 chars
+- **GH02.AC5.1 Success:** `tool_start` event `data.code` is at most 500 characters even when the submitted code is longer
+
+### GH02.AC6: Result preview in tool_done truncated to 200 chars
+- **GH02.AC6.1 Success:** `tool_done` event `data.preview` is at most 200 characters even when the tool output is longer
+
+### GH02.AC7: Integration test verifies full event sequence
+- **GH02.AC7.1 Success:** Test provides `onEvent` callback, runs chat with tool use, verifies all four event kinds fire in correct order
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add emit helper and four emission points to agent loop
+
+**Verifies:** GH02.AC3.1, GH02.AC3.2, GH02.AC4.1, GH02.AC4.2, GH02.AC5.1, GH02.AC6.1
+
+**Files:**
+- Modify: `src/agent/agent.ts`
+
+**Implementation:**
+
+There are three changes to `_chatImpl` in `src/agent/agent.ts`:
+
+**1a. Add the emit helper** inside `_chatImpl`, immediately after the line `const chatStart = performance.now();` (line 73). This goes before any loop logic:
+
+```typescript
+    const emit = async (kind: AgentEventKind, data: Record<string, unknown>): Promise<void> => {
+      if (!options?.onEvent) return;
+      try {
+        await options.onEvent({ kind, data });
+      } catch (err) {
+        process.stderr.write(`[agent] event callback error (${kind}): ${err}\n`);
+      }
+    };
+```
+
+This also requires adding `AgentEventKind` to the import from `./types.ts`. Update the import on line 11:
+
+```typescript
+import type { Agent, AgentDependencies, ChatContext, ChatImage, ChatResult, ChatStats, ChatOptions, AgentEventKind } from './types.ts';
+```
+
+**1b. Add llm_start and llm_done emit calls** in the tool loop. The tool loop starts at line 148. The emit points wrap the `deps.model.complete()` call:
+
+Before the `deps.model.complete()` call (before line 151 `response = await deps.model.complete({`):
+
+```typescript
+        await emit('llm_start', { round });
+```
+
+After the model response is received and usage stats are accumulated (after line 170 `totalOutputTokens += response.usage.output_tokens;`), before the debug `process.stderr.write`:
+
+```typescript
+        await emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason });
+```
+
+**1c. Add tool_start and tool_done emit calls** inside the `toolUseBlocks.map()` callback. Currently (lines 201-223) each tool block is processed. Wrap the runtime execution:
+
+Inside the `toolUseBlocks.map(async (block) => { ... })` callback, after the `code` extraction and validation (after line 204's `typeof code !== 'string'` guard), before the `onToolCall` declaration:
+
+```typescript
+                await emit('tool_start', { tool: 'execute_code', code: (code as string).slice(0, 500) });
+```
+
+After `const result = await deps.runtime.execute(code, undefined, onToolCall);` (after line 213) and before building the output string:
+
+```typescript
+                await emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) });
+```
+
+Note: The `tool_start` emit uses `.slice(0, 500)` and `tool_done` uses `.slice(0, 200)` per the design's truncation requirements.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bunx tsc --noEmit`
+Expected: No type errors.
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bun run build`
+Expected: Build succeeds.
+
+**Commit:** `feat(agent): emit lifecycle events in agent loop`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Integration test for event emission
+
+**Verifies:** GH02.AC3.1, GH02.AC3.2, GH02.AC4.1, GH02.AC4.2, GH02.AC5.1, GH02.AC6.1, GH02.AC7.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Implementation:**
+
+This is the project's first test file. It uses `bun:test` (bun's built-in test runner, already configured via `"test": "bun test"` in `package.json`).
+
+The test strategy is to create mock implementations of `ModelProvider`, `CodeRuntime`, and `Store`, then call `createAgent()` and exercise `chat()` with an `onEvent` callback that records events.
+
+The mock model should return two responses:
+1. First call: `stop_reason: 'tool_use'` with an `execute_code` tool_use block (triggers tool dispatch, so all 4 events fire)
+2. Second call: `stop_reason: 'end_turn'` with a text block (triggers `llm_start` and `llm_done` only)
+
+This produces the expected event sequence: `llm_start`, `llm_done`, `tool_start`, `tool_done`, `llm_start`, `llm_done`.
+
+The test file needs these test cases:
+
+**Test 1: "emits all four event kinds in correct order during tool-use round"**
+- Create agent with mocked deps
+- Call `chat("hello", { onEvent })` where `onEvent` pushes event kinds to an array
+- Assert the collected kinds array equals `['llm_start', 'llm_done', 'tool_start', 'tool_done', 'llm_start', 'llm_done']`
+
+**Test 2: "callback errors are logged, not thrown"**
+- Create agent with mocked deps
+- Provide an `onEvent` that throws on every call
+- Assert `chat()` resolves successfully (does not reject)
+- Assert the result has a non-empty `text` field
+
+**Test 3: "tool_start code is truncated to 500 chars"**
+- Mock the model to submit code longer than 500 characters in the tool_use block
+- Collect events via `onEvent`
+- Find the `tool_start` event and assert `data.code.length <= 500`
+
+**Test 4: "tool_done preview is truncated to 200 chars"**
+- Mock the runtime to return output longer than 200 characters
+- Collect events via `onEvent`
+- Find the `tool_done` event and assert `data.preview.length <= 200`
+
+**Mocking notes for the implementor:**
+
+The `Store` interface (from `src/store/store.ts`) is the hardest to mock because the agent calls `deps.store.docList()` and `loadCoreMemoryFromStore(deps.store)`. The minimal mock needs:
+- `docList()` returning `{ documents: [], total: 0 }`
+- `docGet()` returning `null` (the `loadCoreMemoryFromStore` function calls `store.docGet('self')`)
+
+The `CodeRuntime` mock needs `execute()` returning `{ success: true, output: 'ok', error: null, duration_ms: 1 }`.
+
+The persona file (`deps.personaPath`) must point to a real readable file. Create a temp file with minimal content like `"You are a test agent."` or use `Bun.write` in a `beforeAll`.
+
+The `AgentConfig` needs all required fields:
+```typescript
+{
+  model: 'test-model',
+  maxTokens: 1024,
+  maxToolRounds: 5,
+  contextBudget: 100000,
+  contextLimit: 128000,
+  modelTimeout: 30000,
+  timezone: 'UTC',
+}
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH02 && bun test`
+Expected: All 4 test cases pass.
+
+**Commit:** `test(agent): add event emission integration tests`
+
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/2/implementation-plan/test-requirements.md
+++ b/docs/projects/2/implementation-plan/test-requirements.md
@@ -1,0 +1,77 @@
+# GH02: Event Emission / Lifecycle Hooks — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+### GH02.AC1: AgentEvent and AgentEventKind types exported
+
+| AC | Verification | Type | Notes |
+|----|-------------|------|-------|
+| GH02.AC1.1 | TypeScript compiler (`tsc --noEmit`) | Compile-time | String literal union verified by type system |
+| GH02.AC1.2 | TypeScript compiler (`tsc --noEmit`) | Compile-time | Readonly fields verified by type system |
+| GH02.AC1.3 | TypeScript compiler (`tsc --noEmit`) | Compile-time | Import from `src/agent/index.ts` verified by build |
+
+**Justification for no unit tests:** These are pure type declarations. The TypeScript compiler in strict mode verifies their structure. Type-only exports are verified by the build succeeding.
+
+### GH02.AC2: onEvent callback on ChatOptions is optional
+
+| AC | Verification | Type | Notes |
+|----|-------------|------|-------|
+| GH02.AC2.1 | TypeScript compiler (`tsc --noEmit`) | Compile-time | Optional field type checked by compiler |
+| GH02.AC2.2 | TypeScript compiler (`tsc --noEmit`) + existing callers | Compile-time | Existing call sites omit `onEvent` and must compile |
+
+**Justification for no unit tests:** Optionality is a type-level property. If existing callers compile without providing `onEvent`, the criterion is met. The build gate covers this.
+
+### GH02.AC3: All four events fire in order
+
+| AC | Verification | Type | File |
+|----|-------------|------|------|
+| GH02.AC3.1 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+| GH02.AC3.2 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+
+- **GH02.AC3.1:** Mock model returns `tool_use` then `end_turn`. Assert event sequence `[llm_start, llm_done, tool_start, tool_done, llm_start, llm_done]`.
+- **GH02.AC3.2:** The same test covers this — the second model call (end_turn round) emits `llm_start` and `llm_done` without tool events.
+
+### GH02.AC4: Callback errors are logged, not thrown
+
+| AC | Verification | Type | File |
+|----|-------------|------|------|
+| GH02.AC4.1 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+| GH02.AC4.2 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+
+- **GH02.AC4.1:** Provide `onEvent` that throws. Assert `chat()` resolves (does not reject).
+- **GH02.AC4.2:** Same test — assert `ChatResult.text` is non-empty.
+
+### GH02.AC5: Code preview in tool_start truncated to 500 chars
+
+| AC | Verification | Type | File |
+|----|-------------|------|------|
+| GH02.AC5.1 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+
+- **GH02.AC5.1:** Mock model submits code > 500 chars. Assert `tool_start` event's `data.code` has `length <= 500`.
+
+### GH02.AC6: Result preview in tool_done truncated to 200 chars
+
+| AC | Verification | Type | File |
+|----|-------------|------|------|
+| GH02.AC6.1 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+
+- **GH02.AC6.1:** Mock runtime returns output > 200 chars. Assert `tool_done` event's `data.preview` has `length <= 200`.
+
+### GH02.AC7: Integration test verifies full event sequence
+
+| AC | Verification | Type | File |
+|----|-------------|------|------|
+| GH02.AC7.1 | Automated test | Unit (with mocks) | `src/agent/agent.test.ts` |
+
+- **GH02.AC7.1:** This is the primary test (same as GH02.AC3.1). Provides `onEvent`, runs `chat()` with mocked tool-use round, verifies all four kinds fire in order.
+
+## Human Verification Required
+
+None. All acceptance criteria are either compiler-verified or covered by automated tests.
+
+## Test Infrastructure Notes
+
+- This is the project's first test file. Uses `bun:test` (built-in).
+- No existing test patterns to follow — this test establishes the pattern.
+- Mock strategy: inline mock objects implementing `ModelProvider`, `CodeRuntime`, and minimal `Store` stubs.
+- Persona file: create a temp file in `beforeAll` via `Bun.write`.

--- a/docs/projects/feature-parity-dag.md
+++ b/docs/projects/feature-parity-dag.md
@@ -1,0 +1,386 @@
+# Feature Parity — Build Order DAG
+
+This document defines the dependency graph and implementation steps for all 14 feature-parity issues. Features are grouped into waves that can execute in parallel. Within each wave, independent features can be built by separate agents simultaneously.
+
+## Dependency Graph
+
+```
+Wave 0 (foundations — no dependencies)
+├── #14 Standalone Secrets Management
+├── #11 Extended Thinking / Reasoning Content Preservation
+└── #1  Graceful Max-Iteration Exhaustion
+
+Wave 1 (depends on Wave 0)
+├── #4  Sub-Agent LLM                          (depends on: #14 for secret resolution)
+├── #2  Event Emission / Lifecycle Hooks        (no hard deps, but Wave 0 clears the agent loop)
+├── #12 Dynamic System Prompt Provider          (no hard deps, touches agent loop)
+└── #3  Multi-Tool Architecture                 (no hard deps, major registry refactor)
+
+Wave 2 (depends on Wave 1)
+├── #7  Built-In Web Tools                      (depends on: #3 native tools, #14 secrets)
+├── #6  Outbound Notification Tool              (depends on: #3 native tools, #14 secrets)
+├── #9  Image Viewing Tool                      (depends on: #3 native tools + content block support)
+├── #8  Summarization Tool                      (depends on: #3 native tools, #4 sub-agent)
+└── #5  Auto-Generated Session Titles           (depends on: #4 sub-agent)
+
+Wave 3 (depends on Wave 2)
+├── #10 Custom Tool Creation + Approval         (depends on: #3 multi-tool, #14 secrets)
+└── #13 Multi-Screen TUI                        (depends on: #2 events, #5 titles, #14 secrets, #10 custom tools)
+```
+
+## Edge List (for tooling)
+
+```
+#4  → #14
+#7  → #3, #14
+#6  → #3, #14
+#9  → #3
+#8  → #3, #4
+#5  → #4
+#10 → #3, #14
+#13 → #2, #5, #10, #14
+```
+
+---
+
+## Wave 0 — Foundations
+
+### #14 Standalone Secrets Management
+
+**Status:** Mostly done. `src/secrets/manager.ts` already implements the full `SecretManager` interface (listKeys, get, set, remove, resolve). Stored at `data/secrets.json`.
+
+**Remaining work:**
+1. Verify the existing `SecretManager` type is exported and usable by new consumers (web tools, notification tool, custom tools)
+2. Add `save()` returning a `Promise<void>` that callers can await (currently fire-and-forget)
+3. Add integration test: create manager, set/get/remove/resolve secrets, verify JSON file on disk
+4. No TUI work yet — that's #13
+
+**Files touched:** `src/secrets/manager.ts`, `src/secrets/index.ts`, new test file
+
+---
+
+### #11 Extended Thinking / Reasoning Content Preservation
+
+**Steps:**
+1. Add `ReasoningBlock` to model types: `{ type: 'thinking'; thinking: string }` in `src/model/types.ts`
+2. Add `reasoning_content?: string` field to `ModelResponse` in `src/model/types.ts`
+3. Update each model provider to extract reasoning content from API responses:
+   - `src/model/anthropic.ts` — extract from `thinking` content blocks
+   - `src/model/openrouter.ts` — extract from response metadata / reasoning field
+   - `src/model/openai-compat.ts` — extract if present (o1-style reasoning)
+   - `src/model/ollama.ts` — no-op (local models don't emit reasoning)
+4. In `src/agent/agent.ts`, after building `assistantMessage`, attach `reasoning_content` if present — store it on the message object (extend `Message` type or use a side map)
+5. Update `src/agent/compaction.ts` `formatConversation()` to include reasoning content when serializing for compaction
+6. Add test: mock model response with reasoning → verify it's stored on the assistant message in history
+
+**Files touched:** `src/model/types.ts`, `src/model/anthropic.ts`, `src/model/openrouter.ts`, `src/model/openai-compat.ts`, `src/agent/agent.ts`, `src/agent/compaction.ts`
+
+---
+
+### #1 Graceful Max-Iteration Exhaustion
+
+**Steps:**
+1. In `src/agent/agent.ts`, after the `for` loop (line ~233), detect whether the loop exited because `round === maxToolRounds` (vs. `end_turn`/`max_tokens`)
+2. If exhausted: push a system-style user message `[System: Max tool calls reached. Provide final response now.]` to history
+3. Make one final `deps.model.complete()` call with `tools: []` (no tools available)
+4. Accumulate usage stats from this final call into `totalInputTokens`, `totalOutputTokens`, increment `rounds`
+5. Push the final assistant response to history
+6. Existing text extraction logic at line ~236 handles the rest
+7. Add test: mock model that always returns `tool_use` → verify final forced response after maxToolRounds
+
+**Files touched:** `src/agent/agent.ts`
+
+**Implementation detail:** Track a `let exitedNormally = false` flag. Set it true inside the `end_turn`/`max_tokens` break. After the for-loop, check `if (!exitedNormally)`.
+
+---
+
+## Wave 1 — Core Infrastructure
+
+### #4 Sub-Agent LLM
+
+**Steps:**
+1. Add sub-model config types to `src/config/types.ts`:
+   ```
+   SubModelConfig {
+     provider: 'anthropic' | 'openai-compat';
+     name: string;
+     maxTokens: number;     // default 8000
+     baseUrl?: string;
+     apiKey?: string;
+   }
+   ```
+   Add `subModel?: SubModelConfig` to `AppConfig`.
+2. Add TOML keys `[sub_model]` to `src/config/loader.ts` with env overrides (`SUB_MODEL_NAME`, `SUB_MODEL_API_KEY`, etc.)
+3. Create `src/model/sub-agent.ts` — a lightweight wrapper:
+   - Takes `SubModelConfig`
+   - Implements a simple `complete(prompt: string, system?: string): Promise<string>` (text in, text out — not `ModelProvider`)
+   - Uses Anthropic SDK or fetch-based OpenAI-compat call
+   - Falls back to the main `ModelProvider` if sub-model not configured
+4. Export a `SubAgentLLM` type from `src/model/sub-agent.ts`
+5. Wire up in `src/index.ts`: create `SubAgentLLM` from config, pass into `AgentDependencies`
+6. Add `subAgent?: SubAgentLLM` to `AgentDependencies` in `src/agent/types.ts`
+7. Update compaction (`src/agent/compaction.ts`) to prefer sub-agent for summarization when available
+8. Add test: sub-agent with mocked provider returns expected text
+
+**Files touched:** `src/config/types.ts`, `src/config/loader.ts`, `src/model/sub-agent.ts` (new), `src/agent/types.ts`, `src/agent/compaction.ts`, `src/index.ts`
+
+---
+
+### #2 Event Emission / Lifecycle Hooks
+
+**Steps:**
+1. Define event types in `src/agent/types.ts`:
+   ```
+   type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+   type AgentEvent = { kind: AgentEventKind; data: Record<string, unknown> };
+   ```
+2. Add `onEvent?: (event: AgentEvent) => Promise<void>` to `ChatOptions`
+3. In `src/agent/agent.ts`, create a helper `const emit = async (kind, data) => { if (options?.onEvent) await options.onEvent({ kind, data }); };`
+4. Emit events at four points in the tool loop:
+   - Before `deps.model.complete()`: `emit('llm_start', { round })`
+   - After `deps.model.complete()`: `emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason })`
+   - Before `deps.runtime.execute()`: `emit('tool_start', { tool: 'execute_code', code: code.slice(0, 500) })`
+   - After `deps.runtime.execute()`: `emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) })`
+5. Add test: provide onEvent callback, run chat with tool use, verify all four event kinds fired in order
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`
+
+---
+
+### #12 Dynamic System Prompt Provider
+
+**Steps:**
+1. Add `systemPromptProvider?: () => Promise<string>` to `AgentDependencies` in `src/agent/types.ts`
+2. In `src/agent/agent.ts` `_chatImpl`, before the existing prompt-building block (lines 96-106), check for `deps.systemPromptProvider`:
+   - If present: call it, catch errors and log + fall back to previous cached prompt
+   - If absent: use existing `buildSystemPrompt()` logic (no change)
+3. Store last-good prompt in a closure variable `let cachedSystemPrompt = ''`
+4. Wire up in `src/index.ts`: create a provider function that calls `buildSystemPrompt()` with fresh data from store (self doc, skills, tool docs, secrets list)
+5. This makes the existing prompt-building logic the *default provider* — same behavior, now hookable
+6. Add test: provider that throws → verify fallback to cached prompt
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`, `src/index.ts`
+
+---
+
+### #3 Multi-Tool Architecture
+
+**REVISED:** Keep `execute_code` as primary dispatch. Native tool_use only for tools where the result format demands it (images) or sandbox adds no value (notify, summarize). Existing 8 tools stay sandbox-only. See `docs/projects/3/design.md` for full rationale.
+
+**Steps:**
+1. **Extend ToolRegistry** (`src/runtime/tool-registry.ts`):
+   - Add `mode: 'sandbox' | 'native' | 'both'` per tool entry
+   - Add `generateToolDefinitions(): ToolDefinition[]` — returns definitions for native/both-mode tools only
+   - Existing `generateTypeScriptStubs()` generates stubs for sandbox/both-mode tools only
+   - Existing `generateToolDocumentation()` documents ALL tools regardless of mode
+
+2. **Update agent loop** (`src/agent/agent.ts`):
+   - Build tool list: `[EXECUTE_CODE_TOOL, ...registry.generateToolDefinitions()]`
+   - When dispatching `tool_use` blocks, check tool name:
+     - If `execute_code`: existing Deno sandbox path (unchanged)
+     - If any other registered tool: call `registry.execute(name, input)` directly
+   - Add `formatNativeToolResult()` helper for image content block support
+
+3. **Update model types** (`src/model/types.ts`):
+   - Widen `ToolResultBlock.content` to `string | Array<ContentBlock>`
+
+4. **Existing tools unchanged** — all 8 remain `mode: 'sandbox'`
+
+5. **Native tools (added by later features):**
+   - `view_image` (#9) — `mode: 'native'` (image content blocks)
+   - `notify_discord` (#6) — `mode: 'both'` (native + sandbox for scheduled tasks)
+   - `summarize` (#8) — `mode: 'both'` (native + sandbox for composition)
+
+**Files touched:** `src/runtime/tool-registry.ts`, `src/agent/agent.ts`, `src/model/types.ts`
+
+---
+
+## Wave 2 — Tools and Features
+
+### #7 Built-In Web Tools
+
+**Steps:**
+1. Create `src/tools/web.ts` with three tool definitions:
+   - `web_search` — calls Exa search API (`api.exa.ai/search`)
+   - `fetch_page` — calls Exa contents API (`api.exa.ai/contents`)
+   - `http_get` — plain `fetch()` GET request
+2. Each returns structured JSON results (title, url, snippet, score for search; text + metadata for fetch)
+3. Register all three in `src/agent/tools.ts` via `createAgentTools()` — conditionally based on Exa API key availability
+4. Exa API key resolution: check `deps.secrets?.get('EXA_API_KEY')` then fall back to `process.env.EXA_API_KEY`
+5. `http_get` always available (no API key needed). `web_search` and `fetch_page` return clear error if no Exa key
+6. Add `mode: 'native'` so these are exposed as direct tool_use definitions
+7. Truncation: `max_chars` param (default 10000, cap 50000) for `fetch_page` and `http_get`
+8. Add tests: mock fetch responses, verify structured output
+
+**Files touched:** `src/tools/web.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #6 Outbound Notification Tool (Discord Webhook)
+
+**Steps:**
+1. Create `src/tools/notify.ts` with `notify_discord` tool definition
+2. Parameters: `content` (required string), `title` (optional string)
+3. Implementation:
+   - Get webhook URL from `deps.secrets?.get('DISCORD_WEBHOOK_URL')`
+   - If missing: return error message
+   - If `title` provided: POST JSON with `embeds: [{ title, description: content.slice(0, 2000) }]`
+   - Otherwise: POST JSON with `content: content.slice(0, 2000)`
+4. Register in `src/agent/tools.ts` with `mode: 'native'`
+5. Add test: mock fetch, verify correct webhook payload shape for plain and embed modes
+
+**Files touched:** `src/tools/notify.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #9 Image Viewing Tool
+
+**Steps:**
+1. Create `src/tools/image.ts` with `view_image` tool definition
+2. Parameters: `url` (required string)
+3. Implementation:
+   - `fetch(url)` with timeout
+   - Validate `content-type` starts with `image/`
+   - Reject if `content-length > 10MB`
+   - Read body as `ArrayBuffer`, convert to base64
+   - Return structured result: `{ type: 'image_result', text: 'Image from <url>', image: { type: 'base64', media_type, data } }`
+4. Update agent loop tool result handling in `src/agent/agent.ts`:
+   - When a native tool returns an object with `type: 'image_result'`, format the `ToolResultBlock` content as an array containing both a text block and an Anthropic image block
+   - This requires the `ToolResultBlock.content` update from #3
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock fetch returning PNG bytes → verify base64 encoding and content block structure
+
+**Files touched:** `src/tools/image.ts` (new), `src/agent/tools.ts`, `src/agent/agent.ts` (tool result formatting)
+
+---
+
+### #8 Summarization Tool (via Sub-Agent)
+
+**Steps:**
+1. Create `src/tools/summarize.ts` with `summarize` tool definition
+2. Parameters: `text` (required), `instructions` (optional), `max_length` (optional, enum short/medium/long)
+3. Implementation:
+   - Truncate input at 100k chars
+   - Map `max_length` to guidance string
+   - Call `deps.subAgent.complete(prompt, system)` with summarization system prompt
+   - Return `{ summary: result }`
+4. Guard: if `deps.subAgent` is undefined, return error "Sub-agent LLM not configured"
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock sub-agent, verify prompt construction and result
+
+**Files touched:** `src/tools/summarize.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #5 Auto-Generated Session Titles
+
+**Steps:**
+1. Create `src/agent/session-title.ts`:
+   - `maybeGenerateSessionTitle(store, sessionId, subAgent, messages)` function
+   - Guard: skip if session already has a title, < 2 user messages, or no sub-agent
+   - Take first 10 messages, format as text
+   - Call sub-agent with title generation prompt
+   - Post-process: strip quotes, take first line, cap at 80 chars
+   - Persist via `store.updateSessionTitle(sessionId, title)`
+2. Call from `src/agent/agent.ts` at the end of `_chatImpl` (after returning result, non-blocking)
+3. Need session ID available in agent — add `sessionId?: string` to `ChatOptions`
+4. Add test: mock sub-agent returns title → verify store updated
+
+**Files touched:** `src/agent/session-title.ts` (new), `src/agent/agent.ts`, `src/agent/types.ts`
+
+---
+
+## Wave 3 — Integration Features
+
+### #10 Custom Tool Creation + Approval Workflow
+
+**REVISED:** Sandbox-only dispatch. Custom tools are NOT exposed as native tool_use definitions. Called via `tools.call_custom_tool({ name, params })` inside execute_code. See `docs/projects/10/design.md` for rationale (prompt cache invalidation, composition, approval surface simplicity).
+
+**Steps:**
+1. Create `src/tools/custom-tool-manager.ts`:
+   - `CustomTool` type: `{ name, description, parameters (JSON Schema), code (TypeScript), approved, codeHash, secrets: string[] }`
+   - Storage: `customtool:<name>` documents in the store, content is JSON-serialized `CustomTool`
+   - `listTools()`, `getTool(name)`, `saveTool(tool)`, `approveTool(name)`, `revokeTool(name)`
+   - `getApprovedToolSummaries()`: returns `[{ name, description }]` for system prompt listing
+   - Auto-revoke: on `saveTool`, if code or parameters changed (hash mismatch), set `approved = false`
+
+2. Create `src/tools/custom-tools.ts` — agent-facing tools (all `mode: 'sandbox'`):
+   - `create_custom_tool` — agent provides name, description, parameters schema, code, optional secrets list
+   - `list_custom_tools` — returns all custom tools with approval status
+   - `call_custom_tool` — execute an approved custom tool by name (runs code via Deno sandbox with declared secrets injected)
+
+3. Register in `src/agent/tools.ts` with `mode: 'sandbox'`
+
+4. System prompt integration via #12 provider — lists approved custom tool names + descriptions for discoverability
+
+5. Add tests:
+   - Create tool → verify stored as unapproved
+   - Approve → change code → verify auto-revoked
+   - Call approved tool → verify Deno execution with secrets
+
+**Files touched:** `src/tools/custom-tool-manager.ts` (new), `src/tools/custom-tools.ts` (new), `src/agent/tools.ts`, `src/agent/types.ts`, `src/index.ts`
+
+---
+
+### #13 Multi-Screen TUI
+
+This is the largest UI feature. The current TUI is a single `App.tsx` with chat + review pages.
+
+**Steps:**
+1. **Refactor navigation** — replace `page` state string with a screen stack:
+   - Create `src/tui/types.ts` with `Screen = 'sessions' | 'chat' | 'tools' | 'secrets' | 'schedules' | 'prompt' | 'tool-detail'`
+   - Create `src/tui/Navigation.tsx` — manages screen stack, global key bindings
+
+2. **Session List Screen** (`src/tui/screens/SessionListScreen.tsx`):
+   - List sessions from `store.listSessions()` with titles and dates
+   - `n` = new session, `d` = delete, `Enter` = open in chat
+   - Display model name, secret count, tool counts in header
+
+3. **Chat Screen** — refactor from current `App.tsx`:
+   - Wire `onEvent` callback from #2 to show thinking/running indicators
+   - Show token stats bar from `ChatStats`
+   - `Escape` = back to sessions
+
+4. **Tools Screen** (`src/tui/screens/ToolsScreen.tsx`):
+   - List custom tools from `CustomToolManager` (#10)
+   - Show approval status, description
+   - `a` = approve, `r` = revoke, `Enter` = view detail
+   - Also show built-in tools (read-only)
+
+5. **Secrets Screen** (`src/tui/screens/SecretsScreen.tsx`):
+   - List secret names from `SecretManager` (#14)
+   - `a` = add new secret (prompt for name + value), `d` = delete
+   - Never display values after entry
+
+6. **Schedules Screen** (`src/tui/screens/SchedulesScreen.tsx`):
+   - List tasks from scheduler
+   - Show name, schedule, last run time, status
+   - `e` = enable/disable toggle
+
+7. **System Prompt Screen** (`src/tui/screens/SystemPromptScreen.tsx`):
+   - Display current assembled system prompt (read-only, scrollable)
+   - Useful for debugging what the agent sees
+
+8. **Global navigation keys:** `t` = tools, `s` = secrets, `c` = schedules, `p` = prompt, `q` = quit
+   - These work from any screen
+
+9. **Wire props:** Update `src/index.ts` `startTUI()` to pass scheduler, custom tool manager, and all dependencies
+
+10. Add basic rendering tests for each screen component
+
+**Files touched:** `src/tui/App.tsx` (major refactor), `src/tui/types.ts` (new), `src/tui/Navigation.tsx` (new), `src/tui/screens/` (6 new files), `src/tui/index.ts`, `src/index.ts`
+
+---
+
+## Parallel Execution Plan
+
+```
+Time →
+
+Agent A:  [#14 secrets]──────[#4 sub-agent]────────[#8 summarize]──[#10 custom tools]
+Agent B:  [#11 reasoning]────[#2 events]───────────[#5 titles]─────[#13 TUI]────────→
+Agent C:  [#1 max-iter]──────[#3 multi-tool]───────[#7 web tools]──────────────────→
+Agent D:                     [#12 prompt provider]─[#6 notify]─────[#9 image]──────→
+```
+
+**Merge gates:** Each wave must pass tests before the next wave starts consuming its outputs. Within a wave, agents work on isolated file sets and merge to a shared integration branch at wave boundaries.

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,280 @@
+// pattern: Imperative Shell — agent loop tests with mocked dependencies
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAgent } from './agent.ts';
+import type { AgentConfig, AgentDependencies } from './types.ts';
+import type { Message, ModelProvider, ModelRequest, ModelResponse } from '../model/types.ts';
+import type { CodeRuntime } from '../runtime/types.ts';
+import type { Store, DocumentRow } from '../store/store.ts';
+
+type ModelCall = {
+  request: ModelRequest;
+  toolsCount: number;
+};
+
+function makeStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string) => null as DocumentRow | null,
+    docList: (_limit?: number, _cursor?: string) => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    listMessages: () => [],
+    deleteSession: () => false,
+    saveTask: () => {},
+    getTask: () => null,
+    listTasks: () => [],
+    deleteTask: () => false,
+    updateTaskRun: () => {},
+    grantUpsert: () => {},
+    grantGet: () => null,
+    grantList: () => [],
+    grantDelete: () => false,
+    close: () => {},
+  } as unknown as Store;
+}
+
+function makeRuntime(): CodeRuntime {
+  return {
+    execute: async () => ({
+      success: true,
+      output: 'ok',
+      error: null,
+      duration_ms: 0,
+    }),
+  };
+}
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    model: 'test-model',
+    maxTokens: 1024,
+    maxToolRounds: 2,
+    contextBudget: 0.9,
+    contextLimit: 100_000,
+    modelTimeout: 30_000,
+    temperature: 0,
+    timezone: 'UTC',
+    ...overrides,
+  };
+}
+
+function makeDeps(model: ModelProvider, config: AgentConfig, personaPath: string): AgentDependencies {
+  return {
+    model,
+    runtime: makeRuntime(),
+    config,
+    personaPath,
+    store: makeStore(),
+  };
+}
+
+let personaPath: string;
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'agent-test-'));
+  personaPath = join(tempDir, 'persona.md');
+  await Bun.write(personaPath, '# Test Persona\nYou are a test agent.');
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('graceful max-iteration exhaustion', () => {
+  test('GH01.AC1.1: system nudge appears in history when maxToolRounds exhausted', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 5, output_tokens: 3 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    const overrideHistory = (result as unknown as { history?: Message[] }).history;
+    expect(overrideHistory).toBeUndefined();
+
+    expect(calls.length).toBe(3);
+    expect(calls[2]?.toolsCount).toBe(0);
+
+    expect(result.text).toBe('Forced wrap-up response');
+  });
+
+  test('GH01.AC2.1: final call uses tools: [] and produces text', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Final text' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.text).toBe('Final text');
+    const finalCall = calls[calls.length - 1];
+    expect(finalCall?.request.tools).toEqual([]);
+  });
+
+  test('GH01.AC2.2: usage stats include the forced final call', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'final' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 7, output_tokens: 11 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'x', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 13, output_tokens: 17 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    // 2 loop rounds (13+17 each) + 1 forced (7+11)
+    expect(result.stats.inputTokens).toBe(13 + 13 + 7);
+    expect(result.stats.outputTokens).toBe(17 + 17 + 11);
+  });
+
+  test('GH01.AC2.3: rounds count includes the final call (maxToolRounds + 1)', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'done' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'y', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.stats.rounds).toBe(4);
+  });
+
+  test('GH01.AC3.1: normal end_turn exit injects no nudge and makes one call', async () => {
+    let callCount = 0;
+    const model: ModelProvider = {
+      complete: async (_req) => {
+        callCount++;
+        return {
+          content: [{ type: 'text', text: 'hi' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 4, output_tokens: 2 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 5 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(callCount).toBe(1);
+    expect(result.text).toBe('hi');
+    expect(result.stats.rounds).toBe(1);
+    expect(result.stats.inputTokens).toBe(4);
+    expect(result.stats.outputTokens).toBe(2);
+  });
+
+  test('GH01.AC4.1: end-to-end always-tool_use model produces forced text response', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 9, output_tokens: 6 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('please do work');
+
+    expect(result.text).toBe('Forced wrap-up response');
+    expect(result.stats.rounds).toBe(4);
+    expect(result.stats.inputTokens).toBe(10 * 3 + 9);
+    expect(result.stats.outputTokens).toBe(5 * 3 + 6);
+
+    // Verify calls 1..3 had tools, final had tools: []
+    expect(calls.length).toBe(4);
+    expect(calls[0]?.toolsCount).toBe(1);
+    expect(calls[1]?.toolsCount).toBe(1);
+    expect(calls[2]?.toolsCount).toBe(1);
+    expect(calls[3]?.toolsCount).toBe(0);
+
+    // Verify nudge user message exists in the request sent on the final call.
+    const finalReq = calls[3]?.request;
+    const nudgeMessage = finalReq?.messages.find(
+      (m) => m.role === 'user' && m.content === '[System: Max tool calls reached. Provide final response now.]',
+    );
+    expect(nudgeMessage).toBeDefined();
+  });
+});

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,184 @@
+// pattern: Imperative Shell (test) — exercises agent loop with mocks
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message, ModelRequest } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+import type { Store, DocumentRow, GrantRow } from '../store/store.ts';
+import type { CodeRuntime, ExecutionResult } from '../runtime/types.ts';
+
+function createNoopStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string): DocumentRow | null => null,
+    docList: () => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    getMessages: () => [],
+    clearMessages: () => {},
+    saveTask: () => {},
+    listTasks: () => [],
+    getTask: () => null,
+    updateTaskRun: () => {},
+    deleteTask: () => false,
+    saveGrant: () => {},
+    getGrant: (): GrantRow | null => null,
+    listGrants: () => [],
+    updateGrantStatus: () => {},
+    updateGrantSecrets: () => {},
+    deleteGrant: () => false,
+    close: () => {},
+  };
+}
+
+const noopRuntime: CodeRuntime = {
+  async execute(): Promise<ExecutionResult> {
+    return { success: true, output: '', error: null, duration_ms: 0 };
+  },
+};
+
+describe('agent reasoning_content propagation', () => {
+  let tmpDir: string;
+  let personaPath: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gh11-agent-test-'));
+    personaPath = join(tmpDir, 'persona.md');
+    writeFileSync(personaPath, '# Test Persona\nYou are a test agent.');
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('reasoning_content from model response appears on history message sent to next call', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'I have responded.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+        reasoning_content: 'Let me think step by step about this problem.',
+      },
+      {
+        content: [{ type: 'text', text: 'Second response.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+
+    const first = await agent.chat('first user message');
+    expect(first.text).toBe('I have responded.');
+
+    await agent.chat('second user message');
+
+    // The second call's messages should include the assistant message from the first call.
+    // That assistant message must carry reasoning_content.
+    const secondCallMessages = receivedMessages[1];
+    expect(secondCallMessages).toBeDefined();
+
+    const assistantMessage = secondCallMessages!.find(
+      (m) => m.role === 'assistant',
+    );
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBe(
+      'Let me think step by step about this problem.',
+    );
+  });
+
+  test('absent reasoning_content does not pollute the assistant history message', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'No reasoning here.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      {
+        content: [{ type: 'text', text: 'Done.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+    await agent.chat('first');
+    await agent.chat('second');
+
+    const secondCallMessages = receivedMessages[1];
+    const assistantMessage = secondCallMessages!.find((m) => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBeUndefined();
+  });
+});

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createAgent } from './agent.ts';
-import type { AgentConfig, AgentDependencies } from './types.ts';
+import type { AgentConfig, AgentDependencies, AgentEvent } from './types.ts';
 import type { Message, ModelProvider, ModelRequest, ModelResponse } from '../model/types.ts';
 import type { CodeRuntime, ExecutionResult } from '../runtime/types.ts';
 import type { Store, DocumentRow, GrantRow } from '../store/store.ts';
@@ -399,5 +399,143 @@ describe('graceful max-iteration exhaustion', () => {
       (m) => m.role === 'user' && m.content === '[System: Max tool calls reached. Provide final response now.]',
     );
     expect(nudgeMessage).toBeDefined();
+  });
+});
+
+describe('GH02 event emission', () => {
+  function makeToolUseThenEndModel(toolCode: string, toolOutput?: string): { provider: ModelProvider; runtime: CodeRuntime } {
+    let call = 0;
+    const provider: ModelProvider = {
+      complete: async () => {
+        call++;
+        if (call === 1) {
+          return {
+            content: [{ type: 'tool_use', id: 'call-1', name: 'execute_code', input: { code: toolCode } }],
+            stop_reason: 'tool_use',
+            usage: { input_tokens: 10, output_tokens: 5 },
+          };
+        }
+        return {
+          content: [{ type: 'text', text: 'final answer' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 12, output_tokens: 4 },
+        };
+      },
+    };
+    const runtime: CodeRuntime = {
+      execute: async () => ({
+        success: true,
+        output: toolOutput ?? 'ok',
+        error: null,
+        duration_ms: 1,
+      }),
+    };
+    return { provider, runtime };
+  }
+
+  test('GH02.AC3.1/AC3.2/AC7.1: emits all four event kinds in correct order during tool-use round', async () => {
+    const { provider, runtime } = makeToolUseThenEndModel('output("hello")');
+    const config = makeConfig({ maxToolRounds: 5 });
+    const deps: AgentDependencies = {
+      model: provider,
+      runtime,
+      config,
+      personaPath: sharedPersonaPath,
+      store: makeStore(),
+    };
+    const agent = createAgent(deps);
+
+    const collected: AgentEvent['kind'][] = [];
+    const onEvent = async (event: AgentEvent): Promise<void> => {
+      collected.push(event.kind);
+    };
+
+    const result = await agent.chat('hello', { onEvent });
+
+    expect(collected).toEqual([
+      'llm_start',
+      'llm_done',
+      'tool_start',
+      'tool_done',
+      'llm_start',
+      'llm_done',
+    ]);
+    expect(result.text).toBe('final answer');
+  });
+
+  test('GH02.AC4.1/AC4.2: callback errors are logged, not thrown', async () => {
+    const { provider, runtime } = makeToolUseThenEndModel('output("hi")');
+    const config = makeConfig({ maxToolRounds: 5 });
+    const deps: AgentDependencies = {
+      model: provider,
+      runtime,
+      config,
+      personaPath: sharedPersonaPath,
+      store: makeStore(),
+    };
+    const agent = createAgent(deps);
+
+    const onEvent = async (): Promise<void> => {
+      throw new Error('callback failure');
+    };
+
+    const result = await agent.chat('hello', { onEvent });
+
+    expect(result.text).toBe('final answer');
+    expect(result.text.length).toBeGreaterThan(0);
+  });
+
+  test('GH02.AC5.1: tool_start code is truncated to 500 chars', async () => {
+    const longCode = 'x'.repeat(1200);
+    const { provider, runtime } = makeToolUseThenEndModel(longCode);
+    const config = makeConfig({ maxToolRounds: 5 });
+    const deps: AgentDependencies = {
+      model: provider,
+      runtime,
+      config,
+      personaPath: sharedPersonaPath,
+      store: makeStore(),
+    };
+    const agent = createAgent(deps);
+
+    const events: AgentEvent[] = [];
+    const onEvent = async (event: AgentEvent): Promise<void> => {
+      events.push(event);
+    };
+
+    await agent.chat('hello', { onEvent });
+
+    const toolStart = events.find((e) => e.kind === 'tool_start');
+    expect(toolStart).toBeDefined();
+    const code = toolStart!.data['code'];
+    expect(typeof code).toBe('string');
+    expect((code as string).length).toBeLessThanOrEqual(500);
+  });
+
+  test('GH02.AC6.1: tool_done preview is truncated to 200 chars', async () => {
+    const longOutput = 'y'.repeat(900);
+    const { provider, runtime } = makeToolUseThenEndModel('output("noop")', longOutput);
+    const config = makeConfig({ maxToolRounds: 5 });
+    const deps: AgentDependencies = {
+      model: provider,
+      runtime,
+      config,
+      personaPath: sharedPersonaPath,
+      store: makeStore(),
+    };
+    const agent = createAgent(deps);
+
+    const events: AgentEvent[] = [];
+    const onEvent = async (event: AgentEvent): Promise<void> => {
+      events.push(event);
+    };
+
+    await agent.chat('hello', { onEvent });
+
+    const toolDone = events.find((e) => e.kind === 'tool_done');
+    expect(toolDone).toBeDefined();
+    const preview = toolDone!.data['preview'];
+    expect(typeof preview).toBe('string');
+    expect((preview as string).length).toBeLessThanOrEqual(200);
   });
 });

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -8,7 +8,7 @@ import type {
   ToolDefinition,
   ContentBlock,
 } from '../model/types.ts';
-import type { Agent, AgentDependencies, ChatContext, ChatImage, ChatResult, ChatStats, ChatOptions } from './types.ts';
+import type { Agent, AgentDependencies, ChatContext, ChatImage, ChatResult, ChatStats, ChatOptions, AgentEventKind } from './types.ts';
 import { buildSystemPrompt, estimateTokens, loadCoreMemoryFromStore, repairConversation, trimOldToolResults } from './context.ts';
 import { needsCompaction, compactContext } from './compaction.ts';
 import { createAgentTools } from './tools.ts';
@@ -71,6 +71,14 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
 
   async function _chatImpl(userMessage: string, options?: ChatOptions): Promise<ChatResult> {
     const chatStart = performance.now();
+    const emit = async (kind: AgentEventKind, data: Record<string, unknown>): Promise<void> => {
+      if (!options?.onEvent) return;
+      try {
+        await options.onEvent({ kind, data });
+      } catch (err) {
+        process.stderr.write(`[agent] event callback error (${kind}): ${err}\n`);
+      }
+    };
     currentContext = options?.context ?? {};
     const images = options?.images;
 
@@ -149,6 +157,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
     for (let round = 0; round < deps.config.maxToolRounds; round++) {
       let response;
       try {
+        await emit('llm_start', { round });
         response = await deps.model.complete({
           system: systemPrompt,
           messages: history,
@@ -169,6 +178,8 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
       rounds++;
       totalInputTokens += response.usage.input_tokens;
       totalOutputTokens += response.usage.output_tokens;
+
+      await emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason });
 
       const toolBlocks = response.content.filter(b => b.type === 'tool_use').length;
       const textBlocks = response.content.filter(b => b.type === 'text').length;
@@ -210,12 +221,15 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
                   return { type: 'tool_result', tool_use_id: block.id, content: 'Error: missing code parameter', is_error: true };
                 }
 
+                await emit('tool_start', { tool: 'execute_code', code: code.slice(0, 500) });
+
                 // IPC callback: dispatch tool calls from the sandbox through the registry
                 const onToolCall = async (name: string, params: Record<string, unknown>): Promise<unknown> => {
                   return registry.execute(name, params);
                 };
 
                 const result = await deps.runtime.execute(code, undefined, onToolCall);
+                await emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) });
                 const output = result.success
                   ? result.output || '(no output)'
                   : `Error: ${result.error ?? 'unknown error'}\n${result.output}`;

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -175,6 +175,9 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
 
       // Append assistant response
       const assistantMessage: Message = { role: 'assistant', content: response.content };
+      if (response.reasoning_content) {
+        assistantMessage.reasoning_content = response.reasoning_content;
+      }
       history.push(assistantMessage);
 
       // Check stop reason

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -145,6 +145,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
     }
 
     // e. Tool loop
+    let exitedNormally = false;
     for (let round = 0; round < deps.config.maxToolRounds; round++) {
       let response;
       try {
@@ -180,6 +181,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
       // Check stop reason
       if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
         process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+        exitedNormally = true;
         break;
       }
 
@@ -230,6 +232,32 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
           throw new Error(`Tool dispatch failed: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
     }
 
     // f. Extract final text from last assistant message

--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -1,0 +1,36 @@
+// pattern: Functional Core (test)
+
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -16,7 +16,7 @@ const RECENT_NOTES_COUNT = 3;
 /**
  * Format a conversation history as readable markdown.
  */
-function formatConversation(messages: ReadonlyArray<Message>): string {
+export function formatConversation(messages: ReadonlyArray<Message>): string {
   return messages
     .map((msg) => {
       const content =
@@ -32,7 +32,13 @@ function formatConversation(messages: ReadonlyArray<Message>): string {
               })
               .filter(Boolean)
               .join('\n');
-      return `### ${msg.role}\n${content}`;
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
     })
     .join('\n\n');
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -2,4 +2,4 @@
 
 export { createAgent } from './agent.ts';
 export { buildSystemPrompt, estimateTokens, shouldTruncate } from './context.ts';
-export type { Agent, AgentConfig, AgentDependencies, ConversationTurn } from './types.ts';
+export type { Agent, AgentConfig, AgentDependencies, AgentEvent, AgentEventKind, ConversationTurn } from './types.ts';

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -59,10 +59,18 @@ export type ChatImage = {
   filename?: string;
 };
 
+export type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+
+export type AgentEvent = {
+  readonly kind: AgentEventKind;
+  readonly data: Record<string, unknown>;
+};
+
 export type ChatOptions = {
   readonly context?: ChatContext;
   readonly images?: ChatImage[];
   readonly conversationOverride?: Array<Message>;
+  readonly onEvent?: (event: AgentEvent) => Promise<void>;
 };
 
 export type Agent = {

--- a/src/model/anthropic.ts
+++ b/src/model/anthropic.ts
@@ -20,7 +20,7 @@ function mapStopReason(reason: string | null): StopReason {
   }
 }
 
-function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
   if (block.type === 'text') {
     return { type: 'text', text: block.text };
   }
@@ -31,6 +31,9 @@ function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
       name: block.name,
       input: block.input as Record<string, unknown>,
     };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
   }
   // Fallback: treat unknown block types as text
   return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
@@ -71,7 +74,16 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
         timeout: request.timeout ?? 120_000,
       });
 
-      const content: Array<ContentBlock> = response.content.map(mapContentBlock);
+      const content: Array<ContentBlock> = response.content
+        .map(mapContentBlock)
+        .filter((b): b is ContentBlock => b !== null);
+
+      const thinkingTexts = response.content
+        .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+        .map((b) => b.thinking);
+      const reasoning_content = thinkingTexts.length > 0
+        ? thinkingTexts.join('\n\n')
+        : undefined;
 
       return {
         content,
@@ -86,6 +98,7 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
             (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
               number | null | undefined ?? null,
         },
+        reasoning_content,
       };
     },
   };

--- a/src/model/openai-compat.ts
+++ b/src/model/openai-compat.ts
@@ -35,6 +35,7 @@ type OpenAIChoice = {
   message: {
     role: 'assistant';
     content: string | null;
+    reasoning_content?: string | null;
     tool_calls?: Array<{
       id: string;
       type: 'function';
@@ -271,6 +272,10 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
 
         const choice = data.choices[0]!;
 
+        const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+          ? choice.message.reasoning_content
+          : undefined;
+
         return {
           content: mapResponseContent(choice),
           stop_reason: mapFinishReason(choice.finish_reason),
@@ -278,6 +283,7 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
             input_tokens: data.usage.prompt_tokens,
             output_tokens: data.usage.completion_tokens,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/openrouter.ts
+++ b/src/model/openrouter.ts
@@ -227,6 +227,10 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
 
         process.stderr.write(`[openrouter] finish_reason=${choice.finishReason} tool_calls=${choice.message.toolCalls?.length ?? 0} content_len=${typeof choice.message.content === 'string' ? choice.message.content.length : 0}\n`);
 
+        const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+          ? choice.message.reasoning
+          : undefined;
+
         return {
           content: mapResponseContent(choice.message),
           stop_reason: mapFinishReason(choice.finishReason),
@@ -234,6 +238,7 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
             input_tokens: response.usage?.promptTokens ?? 0,
             output_tokens: response.usage?.completionTokens ?? 0,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -35,6 +35,7 @@ export type ToolDefinition = {
 export type Message = {
   role: 'user' | 'assistant';
   content: string | Array<ContentBlock>;
+  reasoning_content?: string;
 };
 
 export type ModelRequest = {
@@ -60,6 +61,7 @@ export type ModelResponse = {
   content: Array<ContentBlock>;
   stop_reason: StopReason;
   usage: UsageStats;
+  reasoning_content?: string;
 };
 
 export type ModelProvider = {

--- a/src/secrets/manager.test.ts
+++ b/src/secrets/manager.test.ts
@@ -1,0 +1,130 @@
+// Integration tests for SecretManager — verifies persistence lifecycle against real filesystem.
+
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSecretManager } from './manager.ts';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+const TEST_DIR = join(import.meta.dir, '../../.test-tmp');
+const TEST_PATH = join(TEST_DIR, 'secrets.json');
+
+function cleanup(): void {
+  try {
+    rmSync(TEST_DIR, { recursive: true });
+  } catch {
+    // ignore if doesn't exist
+  }
+}
+
+describe('SecretManager', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  test('set() persists to JSON file on disk', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ FOO: 'bar' });
+  });
+
+  test('set() returns a Promise', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const result = mgr.set('X', 'Y');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('remove() returns a Promise', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('X', 'Y');
+    const result = mgr.remove('X');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('get() retrieves a previously set value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('TOKEN', 'abc123');
+    expect(mgr.get('TOKEN')).toBe('abc123');
+  });
+
+  test('get() returns undefined for missing keys', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    expect(mgr.get('NONEXISTENT')).toBeUndefined();
+  });
+
+  test('remove() deletes a secret and persists', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('DEL_ME', 'gone');
+    await mgr.remove('DEL_ME');
+
+    expect(mgr.get('DEL_ME')).toBeUndefined();
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({});
+  });
+
+  test('listKeys() returns sorted key names', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('ZEBRA', 'z');
+    await mgr.set('ALPHA', 'a');
+    await mgr.set('MIDDLE', 'm');
+
+    expect(mgr.listKeys()).toEqual(['ALPHA', 'MIDDLE', 'ZEBRA']);
+  });
+
+  test('resolve() returns env map for existing keys, skips missing', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+    await mgr.set('BAZ', 'qux');
+
+    const env = mgr.resolve(['FOO', 'MISSING', 'BAZ']);
+    expect(env).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('resolve() returns empty object when no keys match', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const env = mgr.resolve(['NOTHING', 'NOPE']);
+    expect(env).toEqual({});
+  });
+
+  test('new manager loads persisted secrets from disk', async () => {
+    const mgr1 = createSecretManager(TEST_PATH);
+    await mgr1.set('PERSIST', 'across-instances');
+
+    const mgr2 = createSecretManager(TEST_PATH);
+    expect(mgr2.get('PERSIST')).toBe('across-instances');
+    expect(mgr2.listKeys()).toEqual(['PERSIST']);
+  });
+
+  test('set() overwrites existing value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('KEY', 'old');
+    await mgr.set('KEY', 'new');
+
+    expect(mgr.get('KEY')).toBe('new');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ KEY: 'new' });
+  });
+
+  test('creates parent directory if it does not exist', async () => {
+    const nested = join(TEST_DIR, 'deep', 'nested', 'secrets.json');
+    const mgr = createSecretManager(nested);
+    await mgr.set('DEEP', 'value');
+
+    const raw = readFileSync(nested, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ DEEP: 'value' });
+  });
+
+  test('ignoring returned promise does not throw (backward compat)', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    // Existing callers call set()/remove() without await — this must not throw
+    mgr.set('IGNORED', 'promise');
+    mgr.remove('IGNORED');
+    // If we get here without error, backward compat is satisfied
+  });
+});

--- a/src/secrets/manager.test.ts
+++ b/src/secrets/manager.test.ts
@@ -40,6 +40,7 @@ describe('SecretManager', () => {
     await mgr.set('X', 'Y');
     const result = mgr.remove('X');
     expect(result).toBeInstanceOf(Promise);
+    await result;
   });
 
   test('get() retrieves a previously set value', async () => {
@@ -120,11 +121,12 @@ describe('SecretManager', () => {
     expect(data).toEqual({ DEEP: 'value' });
   });
 
-  test('ignoring returned promise does not throw (backward compat)', () => {
+  test('ignoring returned promise does not throw (backward compat)', async () => {
     const mgr = createSecretManager(TEST_PATH);
-    // Existing callers call set()/remove() without await — this must not throw
-    mgr.set('IGNORED', 'promise');
-    mgr.remove('IGNORED');
-    // If we get here without error, backward compat is satisfied
+    // Existing callers call set()/remove() without await — this must not throw synchronously
+    const p1 = mgr.set('IGNORED', 'promise');
+    const p2 = mgr.remove('IGNORED');
+    await p1;
+    await p2;
   });
 });

--- a/src/secrets/manager.ts
+++ b/src/secrets/manager.ts
@@ -13,10 +13,10 @@ export type SecretManager = {
   listKeys(): Array<string>;
   /** Get a secret value. Internal only — for env injection. */
   get(key: string): string | undefined;
-  /** Set a secret. */
-  set(key: string, value: string): void;
-  /** Delete a secret. */
-  remove(key: string): void;
+  /** Set a secret. Resolves when persisted to disk. */
+  set(key: string, value: string): Promise<void>;
+  /** Delete a secret. Resolves when persisted to disk. */
+  remove(key: string): Promise<void>;
   /** Resolve secrets for a skill → env var map. Takes an array of key names. */
   resolve(keys: ReadonlyArray<string>): Record<string, string>;
 };
@@ -37,10 +37,9 @@ export function createSecretManager(path: string): SecretManager {
     // File doesn't exist yet — start fresh
   }
 
-  function save(): void {
-    mkdir(dirname(path), { recursive: true })
-      .then(() => writeFile(path, JSON.stringify(secrets, null, 2) + '\n'))
-      .catch(() => {});
+  async function save(): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(secrets, null, 2) + '\n');
   }
 
   return {
@@ -52,14 +51,14 @@ export function createSecretManager(path: string): SecretManager {
       return secrets[key];
     },
 
-    set(key: string, value: string): void {
+    async set(key: string, value: string): Promise<void> {
       secrets[key] = value;
-      save();
+      await save();
     },
 
-    remove(key: string): void {
+    async remove(key: string): Promise<void> {
       delete secrets[key];
-      save();
+      await save();
     },
 
     resolve(keys: ReadonlyArray<string>): Record<string, string> {


### PR DESCRIPTION
## Summary

Adds lifecycle event emission to the agent loop so callers (TUI, Discord, scheduler, future hooks) can observe LLM and tool activity in real time.

- New types `AgentEventKind` and `AgentEvent` in `src/agent/types.ts`, re-exported from the barrel.
- New optional `onEvent` callback on `ChatOptions`. Existing callers compile unchanged.
- Four emission points in `_chatImpl`:
  - `llm_start` / `llm_done` wrap `deps.model.complete()` inside the tool loop.
  - `tool_start` / `tool_done` wrap `deps.runtime.execute()` inside the `toolUseBlocks.map()` callback.
- `tool_start.data.code` truncated to 500 chars; `tool_done.data.preview` truncated to 200 chars.
- Callback errors are caught and written to stderr so a misbehaving listener cannot interrupt the loop.

## Wave 0 dependencies

Merged in from `origin/GH14`, `origin/GH11`, and `origin/GH01`. The `src/agent/agent.test.ts` add/add conflict between GH11 and GH01 was resolved by combining both describe blocks against the canonical `Store` interface.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — succeeds
- [x] `bun test` — 27/27 pass, including 4 new GH02 tests:
  - All four events fire in order during a tool-use round (`llm_start, llm_done, tool_start, tool_done, llm_start, llm_done`)
  - Callback that throws on every call does not break `chat()`
  - `tool_start.code` length <= 500 with 1200-char input
  - `tool_done.preview` length <= 200 with 900-char output

🤖 Generated with [Claude Code](https://claude.com/claude-code)