### PR TITLE
GH08: Summarization tool backed by sub-agent LLM

### DIFF
--- a/docs/projects/1/design.md
+++ b/docs/projects/1/design.md
@@ -1,0 +1,66 @@
+# #1 — Graceful Max-Iteration Exhaustion
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/1
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+When `maxToolRounds` is hit, the for-loop in `_chatImpl` exits silently. The text extraction logic at the end grabs whatever was in the last assistant message — often a `tool_use` block with no text, or mid-thought content.
+
+## Design
+
+### Flag-based detection
+
+Add a `let exitedNormally = false` flag before the for-loop. Set it `true` inside the `end_turn`/`max_tokens` break (line ~183). After the for-loop, check the flag.
+
+### Forced final response
+
+If `!exitedNormally`:
+
+1. Push a system nudge as a user message:
+   ```
+   history.push({ role: 'user', content: '[System: Max tool calls reached. Provide final response now.]' });
+   ```
+
+2. Make one final model call with **no tools**:
+   ```
+   const finalResponse = await deps.model.complete({
+     system: systemPrompt,
+     messages: history,
+     tools: [],          // forces text-only response
+     model: deps.config.model,
+     max_tokens: deps.config.maxTokens,
+     temperature: deps.config.temperature,
+     timeout: deps.config.modelTimeout,
+   });
+   ```
+
+3. Accumulate usage stats:
+   ```
+   rounds++;
+   totalInputTokens += finalResponse.usage.input_tokens;
+   totalOutputTokens += finalResponse.usage.output_tokens;
+   ```
+
+4. Push final assistant response to history:
+   ```
+   history.push({ role: 'assistant', content: finalResponse.content });
+   ```
+
+5. Existing text extraction logic at the end of `_chatImpl` handles the rest — it finds the last assistant message and extracts text blocks.
+
+### Why `tools: []` works
+
+With no tools in the request, the model cannot return `tool_use` blocks. It must produce text. This guarantees a coherent wrap-up response.
+
+## Files Touched
+
+- `src/agent/agent.ts` — ~20 lines after the for-loop
+
+## Acceptance Criteria
+
+1. When maxToolRounds exhausted, a system nudge message appears in history
+2. A final model call with `tools: []` produces a text response
+3. Usage stats from the final call are included in `ChatStats`
+4. `rounds` count includes the final call
+5. Test: mock model that always returns `tool_use` → verify final forced text response after maxToolRounds

--- a/docs/projects/1/implementation-plan/phase_01.md
+++ b/docs/projects/1/implementation-plan/phase_01.md
@@ -1,0 +1,204 @@
+# GH01: Graceful Max-Iteration Exhaustion — Implementation Plan
+
+**Goal:** When the agent's tool loop exhausts `maxToolRounds`, produce a coherent text response instead of silently returning whatever was in the last (likely incomplete) assistant message.
+
+**Architecture:** Add an `exitedNormally` flag to the existing `for` loop in `_chatImpl`. When the loop exits without an `end_turn`/`max_tokens` break, push a system nudge and make one final model call with `tools: []` to force a text-only wrap-up.
+
+**Tech Stack:** TypeScript, Bun test runner (`bun:test`)
+
+**Scope:** 1 phase (complete feature)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH01.AC1: System nudge on exhaustion
+- **GH01.AC1.1 Success:** When maxToolRounds exhausted, a system nudge message appears in history
+
+### GH01.AC2: Forced text-only final call
+- **GH01.AC2.1 Success:** A final model call with `tools: []` produces a text response
+- **GH01.AC2.2 Success:** Usage stats from the final call are included in `ChatStats`
+- **GH01.AC2.3 Success:** `rounds` count includes the final call
+
+### GH01.AC3: Normal exit unaffected
+- **GH01.AC3.1 Success:** When the loop exits via `end_turn` or `max_tokens`, no nudge is injected and no extra model call is made
+
+### GH01.AC4: Integration test
+- **GH01.AC4.1 Success:** Mock model that always returns `tool_use` produces a final forced text response after maxToolRounds
+
+---
+
+## Phase 1: Flag-Based Exhaustion Detection and Forced Final Response
+
+This is a functionality phase. All changes are in `src/agent/agent.ts` with a new test file at `src/agent/agent.test.ts`.
+
+<!-- START_SUBCOMPONENT_A (tasks 1-4) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `exitedNormally` flag and forced final response logic
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1
+
+**Files:**
+- Modify: `src/agent/agent.ts:147-233` (the tool loop and the code immediately after it)
+
+**Implementation:**
+
+Before the `for` loop at line 148, add:
+
+```typescript
+let exitedNormally = false;
+```
+
+Inside the `end_turn`/`max_tokens` break at line 181-184, set the flag before breaking:
+
+```typescript
+if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
+  process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+  exitedNormally = true;
+  break;
+}
+```
+
+After the closing `}` of the `for` loop (line 233) and before the `// f. Extract final text` comment (line 235), insert the forced final response block:
+
+```typescript
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
+    }
+```
+
+**Key details:**
+- `tools: []` prevents the model from returning `tool_use` blocks — it must produce text.
+- The nudge is a plain string user message, not an array of content blocks. This matches how the agent already pushes user messages (line 121).
+- Usage stats are accumulated into the existing `totalInputTokens`/`totalOutputTokens`/`rounds` variables. The final `ChatStats` object at line 246 already reads from these, so no further changes needed.
+- The existing text extraction logic at line 235-263 handles the rest — it finds the last assistant message and extracts text blocks. Since the forced response is the last assistant message and contains only text blocks (no `tool_use` possible), it works as-is.
+
+**Verification:**
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+**Commit:** `feat(agent): add exitedNormally flag and forced final response on max-iteration exhaustion`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Write tests for max-iteration exhaustion
+
+**Verifies:** GH01.AC1.1, GH01.AC2.1, GH01.AC2.2, GH01.AC2.3, GH01.AC3.1, GH01.AC4.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Context for test construction:**
+
+The `createAgent` function (exported from `src/agent/agent.ts`) takes an `AgentDependencies` object. The key deps to mock are:
+
+1. **`model: ModelProvider`** — needs a `complete()` method returning `ModelResponse`. The mock controls `stop_reason` and `content` to simulate tool_use vs end_turn behaviour.
+
+2. **`runtime: CodeRuntime`** — needs an `execute()` method returning `ExecutionResult`. For these tests, the runtime mock just returns a success result since we're testing loop exit behaviour, not tool execution.
+
+3. **`store: Store`** — the agent calls `store.docGet('self')` and `store.docList(500)` during prompt building. Mock these to return minimal data.
+
+4. **`config: AgentConfig`** — set `maxToolRounds` to a small number (e.g., 2 or 3) to trigger exhaustion quickly.
+
+5. **`personaPath: string`** — points to a file read with `Bun.file().text()`. Create a temp file or use an existing fixture.
+
+The agent also writes to `src/runtime/deno/tools.ts` via `Bun.write`. Ensure the directory exists or mock accordingly.
+
+**Testing:**
+
+Tests must verify each AC listed above:
+
+- **GH01.AC1.1:** After the model returns `tool_use` for every round up to `maxToolRounds`, assert that history contains a user message with content `'[System: Max tool calls reached. Provide final response now.]'`.
+
+- **GH01.AC2.1:** Assert the mock model's `complete` was called one final time after the loop with `tools: []` in the request, and the returned `ChatResult.text` contains the forced response text.
+
+- **GH01.AC2.2:** Assert `ChatResult.stats.inputTokens` and `stats.outputTokens` include the usage from the final forced call (sum of all rounds including the forced one).
+
+- **GH01.AC2.3:** Assert `ChatResult.stats.rounds` equals `maxToolRounds + 1` (the loop rounds plus the forced final call).
+
+- **GH01.AC3.1:** When the model returns `end_turn` on the first call, assert no nudge message in history, `stats.rounds` equals 1, and `complete` was called exactly once.
+
+- **GH01.AC4.1:** End-to-end mock scenario: model always returns `tool_use` except when called with `tools: []` (then returns text). Verify the agent returns the forced text response and all stats are correct.
+
+**Mock strategy:**
+
+The model mock should track call count and inspect the `tools` parameter:
+- When `tools` contains `EXECUTE_CODE_TOOL`: return a `tool_use` response with a dummy tool call
+- When `tools` is `[]`: return an `end_turn` response with a text block containing known text (e.g., `"Forced wrap-up response"`)
+
+The runtime mock returns `{ success: true, output: 'ok', error: null, duration_ms: 0 }` for all executions.
+
+The store mock returns `null` for `docGet` and `{ documents: [], total: 0 }` for `docList`.
+
+Create a temp persona file using `Bun.write` in a `beforeAll` block pointing to a temp directory (`import { mkdtemp } from 'node:fs/promises'`), containing minimal persona text.
+
+**Verification:**
+Run: `bun test`
+Expected: All tests pass
+
+**Commit:** `test(agent): add tests for graceful max-iteration exhaustion`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Run full verification
+
+**Files:** None (verification only)
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds with no type errors
+
+Run: `bun test`
+Expected: All tests pass
+
+Run: `bun run build && bun test`
+Expected: Both succeed
+
+This task has no commit — it's a verification gate.
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Final commit
+
+**Files:** None (commit only — all changes from Tasks 1-2 should already be committed)
+
+**Verification:**
+
+Run: `git status`
+Expected: Working tree clean, all changes committed
+
+Run: `git log --oneline -3`
+Expected: Two commits visible — implementation and tests
+
+This task exists to ensure everything is committed and the branch is clean.
+<!-- END_TASK_4 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/1/implementation-plan/test-requirements.md
+++ b/docs/projects/1/implementation-plan/test-requirements.md
@@ -1,0 +1,18 @@
+# GH01: Graceful Max-Iteration Exhaustion — Test Requirements
+
+Maps each acceptance criterion to automated tests. All tests are unit tests in `src/agent/agent.test.ts` using `bun:test`.
+
+## Automated Tests
+
+| AC ID | Criterion | Test Type | Test File | Test Description |
+|-------|-----------|-----------|-----------|------------------|
+| GH01.AC1.1 | System nudge appears in history on exhaustion | unit | `src/agent/agent.test.ts` | After model returns `tool_use` for all `maxToolRounds`, inspect history for user message containing `'[System: Max tool calls reached. Provide final response now.]'` |
+| GH01.AC2.1 | Final call with `tools: []` produces text | unit | `src/agent/agent.test.ts` | Mock model returns text when `tools` is `[]`. Assert `ChatResult.text` matches the forced response text. Assert model was called with `tools: []` on the final call. |
+| GH01.AC2.2 | Final call usage stats included in ChatStats | unit | `src/agent/agent.test.ts` | Mock model returns known usage values per call. Assert `stats.inputTokens` and `stats.outputTokens` equal the sum across all calls including the forced one. |
+| GH01.AC2.3 | Rounds count includes final call | unit | `src/agent/agent.test.ts` | With `maxToolRounds: N`, assert `stats.rounds` equals `N + 1` when exhaustion occurs. |
+| GH01.AC3.1 | Normal exit unaffected | unit | `src/agent/agent.test.ts` | Model returns `end_turn` immediately. Assert no nudge in history, `stats.rounds` equals 1, model called exactly once. |
+| GH01.AC4.1 | Integration: always-tool_use model forced to text | unit | `src/agent/agent.test.ts` | End-to-end scenario: model returns `tool_use` until `tools: []`, then returns text. Verify returned text, correct round count, correct token sums. |
+
+## Human Verification
+
+None required. All acceptance criteria are testable via automated unit tests with mocked dependencies.

--- a/docs/projects/11/design.md
+++ b/docs/projects/11/design.md
@@ -1,0 +1,82 @@
+# #11 — Extended Thinking / Reasoning Content Preservation
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/11
+**Wave:** 0 (no dependencies)
+
+## Current State
+
+OpenRouter config supports `reasoning` effort level (`none | low | medium | high`), but reasoning content from model responses is discarded. Not stored in conversation history, not available for compaction or debugging.
+
+## Design
+
+### Approach: Field on Message (Option A)
+
+Add `reasoning_content?: string` directly to the `Message` type. This is metadata that most consumers can ignore. The `Message` type is internal, not an API contract.
+
+### Model Response
+
+Add `reasoning_content?: string` to `ModelResponse` in `src/model/types.ts`. Each provider extracts it from the raw API response.
+
+### Provider Changes
+
+**`src/model/anthropic.ts`**
+- Claude returns thinking as `thinking` content blocks in the response
+- Concatenate all `thinking` block text into a single `reasoning_content` string
+- Set on the `ModelResponse`
+
+**`src/model/openrouter.ts`**
+- OpenRouter surfaces reasoning in response metadata (varies by underlying model)
+- Extract from the response if present
+
+**`src/model/openai-compat.ts`**
+- o1-style models may include reasoning tokens
+- Extract if present in the response structure
+
+**`src/model/ollama.ts`**
+- Local models don't emit reasoning content
+- No-op — leave `reasoning_content` undefined
+
+**`src/model/lemonade.ts`** (if separate from openai-compat)
+- Same treatment as openai-compat — extract reasoning if present in the response
+- Lemonade is an OpenAI-compat variant, so the extraction logic should mirror that provider
+
+### Agent Loop
+
+In `src/agent/agent.ts`, after building `assistantMessage` (line ~177):
+- Check `response.reasoning_content`
+- If present, attach to the message: `assistantMessage.reasoning_content = response.reasoning_content`
+
+### Compaction
+
+In `src/agent/compaction.ts` `formatConversation()`:
+- When serializing assistant messages, include reasoning content if present
+- Format as: `### assistant (reasoning)\n{reasoning_content}\n### assistant\n{content}`
+- This lets the summarizer see why decisions were made
+
+### Message Serialization
+
+In `src/agent/messages.ts`:
+- When serializing messages to/from store, preserve the `reasoning_content` field
+- JSON serialization handles this naturally if the field exists
+
+## Files Touched
+
+- `src/model/types.ts` — add `reasoning_content?: string` to `ModelResponse` and `Message`
+- `src/model/anthropic.ts` — extract from thinking blocks
+- `src/model/openrouter.ts` — extract from response metadata
+- `src/model/openai-compat.ts` — extract if present (covers lemonade)
+- `src/model/ollama.ts` — no-op (verify no crash if field absent)
+- `src/agent/agent.ts` — attach reasoning to assistant message
+- `src/agent/compaction.ts` — include reasoning in formatted conversation
+
+## Acceptance Criteria
+
+1. `ModelResponse` has optional `reasoning_content` field
+2. `Message` has optional `reasoning_content` field
+3. Anthropic provider extracts thinking blocks into `reasoning_content`
+4. OpenRouter provider extracts reasoning metadata
+5. OpenAI-compat / lemonade providers extract reasoning if present
+6. Agent loop attaches reasoning to assistant messages in history
+7. Compaction serializer includes reasoning content when formatting
+8. No display in TUI (preserved in data only)
+9. Test: mock model response with reasoning → verify stored on assistant message in history

--- a/docs/projects/11/implementation-plan/phase_01.md
+++ b/docs/projects/11/implementation-plan/phase_01.md
@@ -1,0 +1,108 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 1
+
+**Goal:** Add the `reasoning_content` optional field to `ModelResponse` and `Message` types so providers can surface reasoning and the agent loop can propagate it.
+
+**Architecture:** A single optional string field on both the response type (provider output) and the message type (conversation history). Consumers that don't care about reasoning ignore the field. No schema migrations needed — messages are serialized as JSON strings in SQLite and the field survives naturally.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime
+
+**Scope:** 3 phases total (this is phase 1 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC1: ModelResponse has optional reasoning_content field
+- **GH11.AC1.1 Success:** `ModelResponse` type includes `reasoning_content?: string`
+
+### GH11.AC2: Message has optional reasoning_content field
+- **GH11.AC2.1 Success:** `Message` type includes `reasoning_content?: string`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `reasoning_content` to `ModelResponse`
+
+**Verifies:** GH11.AC1.1
+
+**Files:**
+- Modify: `src/model/types.ts:59-63`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `ModelResponse` type. This is the provider-facing output — each provider sets it when reasoning content is present in the API response.
+
+In `src/model/types.ts`, the current `ModelResponse` type (lines 59-63) is:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+};
+```
+
+Add the field:
+
+```typescript
+export type ModelResponse = {
+  content: Array<ContentBlock>;
+  stop_reason: StopReason;
+  usage: UsageStats;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The field is optional so all existing provider return sites remain valid.
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add `reasoning_content` to `Message`
+
+**Verifies:** GH11.AC2.1
+
+**Files:**
+- Modify: `src/model/types.ts:35-38`
+
+**Implementation:**
+
+Add `reasoning_content?: string` to the `Message` type. This is the conversation history type — the agent loop attaches reasoning content to assistant messages so it persists across the session.
+
+The current `Message` type (lines 35-38) is:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+};
+```
+
+Add the field:
+
+```typescript
+export type Message = {
+  role: 'user' | 'assistant';
+  content: string | Array<ContentBlock>;
+  reasoning_content?: string;
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. All existing message construction sites pass because the field is optional.
+
+**Commit:** `feat(types): add reasoning_content field to ModelResponse and Message`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/11/implementation-plan/phase_02.md
+++ b/docs/projects/11/implementation-plan/phase_02.md
@@ -1,0 +1,257 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 2
+
+**Goal:** Extract reasoning content from each model provider's API response and set it on the `ModelResponse`.
+
+**Architecture:** Each provider has a different response format for reasoning. Anthropic returns `thinking` content blocks. OpenRouter surfaces a `reasoning` string on the assistant message. OpenAI-compat may include reasoning in the response (o1-style models). Ollama does not emit reasoning — no-op. Each provider extracts and concatenates reasoning text into the single `reasoning_content` string field added in Phase 1.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, `@anthropic-ai/sdk` (v0.39+), `@openrouter/sdk` (v0.12+)
+
+**Scope:** 3 phases total (this is phase 2 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH11.AC3: Anthropic provider extracts thinking blocks into reasoning_content
+- **GH11.AC3.1 Success:** When Claude returns `thinking` content blocks, they are concatenated into `reasoning_content` on the `ModelResponse`
+- **GH11.AC3.2 No-op:** When no thinking blocks are present, `reasoning_content` is `undefined`
+
+### GH11.AC4: OpenRouter provider extracts reasoning metadata
+- **GH11.AC4.1 Success:** When OpenRouter response includes `reasoning` on the assistant message, it is set as `reasoning_content`
+- **GH11.AC4.2 No-op:** When `reasoning` is absent/null, `reasoning_content` is `undefined`
+
+### GH11.AC5: OpenAI-compat / lemonade providers extract reasoning if present
+- **GH11.AC5.1 Success:** When response includes a `reasoning_content` field on the message, it is extracted
+- **GH11.AC5.2 No-op:** When field is absent, `reasoning_content` is `undefined`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Anthropic provider — extract thinking blocks
+
+**Verifies:** GH11.AC3.1, GH11.AC3.2
+
+**Files:**
+- Modify: `src/model/anthropic.ts:23-37` (mapContentBlock function)
+- Modify: `src/model/anthropic.ts:70-89` (complete function, response mapping + return)
+
+**Implementation:**
+
+The Anthropic SDK's `ContentBlock` union already includes `ThinkingBlock` (`{ type: 'thinking'; thinking: string; signature: string }`) and `RedactedThinkingBlock` (`{ type: 'redacted_thinking' }`). The current `mapContentBlock` function has a fallback for unknown block types but does not handle `thinking` explicitly.
+
+Two changes needed:
+
+**1. Update `mapContentBlock` to skip thinking blocks.**
+
+Thinking blocks should not be mapped into the agent's `ContentBlock[]` — they are metadata, not content the agent acts on. The function currently falls through to a text fallback for unknown types. Add an explicit case that returns `null` for thinking blocks, and filter nulls from the result.
+
+Replace the current `mapContentBlock` and the line that calls it:
+
+```typescript
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
+  if (block.type === 'text') {
+    return { type: 'text', text: block.text };
+  }
+  if (block.type === 'tool_use') {
+    return {
+      type: 'tool_use',
+      id: block.id,
+      name: block.name,
+      input: block.input as Record<string, unknown>,
+    };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
+  }
+  // Fallback: treat unknown block types as text
+  return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
+}
+```
+
+Update the content mapping in `complete()` (currently line 74):
+
+```typescript
+const content: Array<ContentBlock> = response.content
+  .map(mapContentBlock)
+  .filter((b): b is ContentBlock => b !== null);
+```
+
+**2. Extract reasoning content from thinking blocks.**
+
+After the content mapping, concatenate all `thinking` block text into `reasoning_content`:
+
+```typescript
+const thinkingTexts = response.content
+  .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+  .map((b) => b.thinking);
+const reasoning_content = thinkingTexts.length > 0
+  ? thinkingTexts.join('\n\n')
+  : undefined;
+```
+
+Then include it in the return:
+
+```typescript
+return {
+  content,
+  stop_reason: mapStopReason(response.stop_reason),
+  usage: {
+    input_tokens: response.usage.input_tokens,
+    output_tokens: response.usage.output_tokens,
+    cache_creation_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_creation_input_tokens'] as
+        number | null | undefined ?? null,
+    cache_read_input_tokens:
+      (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
+        number | null | undefined ?? null,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(anthropic): extract thinking blocks into reasoning_content`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: OpenRouter provider — extract reasoning field
+
+**Verifies:** GH11.AC4.1, GH11.AC4.2
+
+**Files:**
+- Modify: `src/model/openrouter.ts:223-237` (return statement in complete function)
+
+**Implementation:**
+
+The OpenRouter SDK's `ChatAssistantMessage` type includes `reasoning?: string | null | undefined`. The current code accesses `choice.message` but does not read `reasoning`.
+
+After the existing debug log line (line 228), extract the reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+  ? choice.message.reasoning
+  : undefined;
+```
+
+Then include it in the return object (currently lines 230-237):
+
+```typescript
+return {
+  content: mapResponseContent(choice.message),
+  stop_reason: mapFinishReason(choice.finishReason),
+  usage: {
+    input_tokens: response.usage?.promptTokens ?? 0,
+    output_tokens: response.usage?.completionTokens ?? 0,
+  },
+  reasoning_content,
+};
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openrouter): extract reasoning into reasoning_content`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: OpenAI-compat provider — extract reasoning if present
+
+**Verifies:** GH11.AC5.1, GH11.AC5.2
+
+**Files:**
+- Modify: `src/model/openai-compat.ts:34-45` (OpenAIChoice type)
+- Modify: `src/model/openai-compat.ts:270-281` (return statement in complete function)
+
+**Implementation:**
+
+Some OpenAI-compatible providers (e.g., o1-style models, DeepSeek-R1 via compatible endpoints) return reasoning in the response. The field name varies but the most common convention is `reasoning_content` on the message object. The current `OpenAIChoice` type does not include this field.
+
+**1. Extend the `OpenAIChoice` type** to accept an optional reasoning field on the message:
+
+```typescript
+type OpenAIChoice = {
+  message: {
+    role: 'assistant';
+    content: string | null;
+    reasoning_content?: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }>;
+  };
+  finish_reason: string;
+};
+```
+
+**2. Extract reasoning in the return.** After getting `choice` (line 272), extract reasoning:
+
+```typescript
+const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+  ? choice.message.reasoning_content
+  : undefined;
+```
+
+Include in the return:
+
+```typescript
+return {
+  content: mapResponseContent(choice),
+  stop_reason: mapFinishReason(choice.finish_reason),
+  usage: {
+    input_tokens: data.usage.prompt_tokens,
+    output_tokens: data.usage.completion_tokens,
+  },
+  reasoning_content,
+};
+```
+
+**Note:** This also covers the `lemonade` provider case from the design — there is no separate `src/model/lemonade.ts` file. Lemonade uses the OpenAI-compat provider, so this change covers both.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(openai-compat): extract reasoning_content from response`
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Ollama provider — verify no-op
+
+**Verifies:** None (verification that existing provider doesn't crash with the new optional field)
+
+**Files:**
+- No modifications to `src/model/ollama.ts`
+
+**Implementation:**
+
+No code changes. The Ollama provider's `complete()` method returns a `ModelResponse` without `reasoning_content`, which is valid because the field is optional. Local models served by Ollama do not emit reasoning content.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors. The Ollama provider compiles cleanly without setting `reasoning_content` because the field is optional on `ModelResponse`.
+
+No commit needed for this task — it's a verification step only.
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/phase_03.md
+++ b/docs/projects/11/implementation-plan/phase_03.md
@@ -1,0 +1,308 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Phase 3
+
+**Goal:** Wire reasoning content through the agent loop (attach to assistant messages in history), include it in compaction serialization, and add a test proving the end-to-end flow.
+
+**Architecture:** The agent loop in `agent.ts` builds an `assistantMessage` from the model response. We attach `reasoning_content` from the response to the message. The compaction serializer in `compaction.ts` already formats messages into markdown — we prepend reasoning content as a separate section when present. A new test file verifies the full flow: mock model returns reasoning, verify it lands on the history message and appears in compaction output.
+
+**Tech Stack:** TypeScript strict mode, Bun runtime, Bun test runner
+
+**Scope:** 3 phases total (this is phase 3 of 3)
+
+**Codebase verified:** 2026-04-27 via direct investigation
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH11.AC6: Agent loop attaches reasoning to assistant messages in history
+- **GH11.AC6.1 Success:** When `response.reasoning_content` is present, it is set on the assistant message pushed to history
+- **GH11.AC6.2 No-op:** When `response.reasoning_content` is undefined, the message has no `reasoning_content` field
+
+### GH11.AC7: Compaction serializer includes reasoning content when formatting
+- **GH11.AC7.1 Success:** When an assistant message has `reasoning_content`, `formatConversation()` includes it in the output as `### assistant (reasoning)\n{reasoning_content}` before the main `### assistant\n{content}` block
+- **GH11.AC7.2 No-op:** When no `reasoning_content` is present, formatting is unchanged
+
+### GH11.AC8: No display in TUI (preserved in data only)
+- **GH11.AC8.1 Verification:** No changes to any TUI component. Reasoning content exists only on the `Message` type and in compaction output.
+
+### GH11.AC9: Test — mock model response with reasoning, verify stored on assistant message
+- **GH11.AC9.1 Success:** A test with a mock model returning `reasoning_content` verifies the field appears on the assistant message in history
+- **GH11.AC9.2 Success:** A test verifies `formatConversation()` includes reasoning in the serialized output
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Agent loop — attach reasoning to assistant message
+
+**Verifies:** GH11.AC6.1, GH11.AC6.2
+
+**Files:**
+- Modify: `src/agent/agent.ts:177` (assistant message construction)
+
+**Implementation:**
+
+In `_chatImpl`, after the model call, the assistant message is constructed at line 177:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+```
+
+Add reasoning content propagation immediately after this line:
+
+```typescript
+const assistantMessage: Message = { role: 'assistant', content: response.content };
+if (response.reasoning_content) {
+  assistantMessage.reasoning_content = response.reasoning_content;
+}
+```
+
+This is a simple conditional assignment. When `reasoning_content` is undefined (the common case for most models), nothing happens. When present (e.g., Anthropic thinking blocks, OpenRouter reasoning), it's preserved on the message in history.
+
+**Note on TUI (GH11.AC8):** No TUI files need changes. The `ChatResult` type returned by `chat()` contains only `text` and `stats` — reasoning content is preserved in the internal `history` array and in compaction output, but never surfaced to the UI layer.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(agent): attach reasoning_content to assistant messages in history`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Compaction — include reasoning in formatted conversation
+
+**Verifies:** GH11.AC7.1, GH11.AC7.2
+
+**Files:**
+- Modify: `src/agent/compaction.ts:19-37` (formatConversation function)
+
+**Implementation:**
+
+The `formatConversation` function serializes messages into markdown for context compaction. Currently it formats each message as `### {role}\n{content}`. When an assistant message has `reasoning_content`, we should include it so the summarizer can see the model's reasoning chain.
+
+The current function (lines 19-37):
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+      return `### ${msg.role}\n${content}`;
+    })
+    .join('\n\n');
+}
+```
+
+Replace it with:
+
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+  return messages
+    .map((msg) => {
+      const content =
+        typeof msg.content === 'string'
+          ? msg.content
+          : msg.content
+              .map((block) => {
+                if (block.type === 'text') return block.text;
+                if (block.type === 'image_url') return '[image]';
+                if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                return '';
+              })
+              .filter(Boolean)
+              .join('\n');
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
+    })
+    .join('\n\n');
+}
+```
+
+When `reasoning_content` is present, the output for that message becomes:
+
+```
+### assistant (reasoning)
+{reasoning text here}
+
+### assistant
+{actual response content}
+```
+
+When absent, output is identical to the previous format: `### assistant\n{content}`.
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && npx tsc --noEmit`
+Expected: No type errors.
+
+**Commit:** `feat(compaction): include reasoning_content in formatted conversation`
+
+<!-- END_TASK_2 -->
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 3-4) -->
+
+<!-- START_TASK_3 -->
+### Task 3: Test — reasoning content flows through agent loop
+
+**Verifies:** GH11.AC9.1
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Implementation:**
+
+Create a test that exercises the agent loop with a mock model that returns `reasoning_content`. The test verifies that the reasoning appears on the assistant message in history.
+
+The test needs to mock several dependencies:
+- `ModelProvider` — returns a `ModelResponse` with `reasoning_content` and `stop_reason: 'end_turn'`
+- `CodeRuntime` — not needed (model stops on first call, no tool use)
+- `Store` — minimal mock that returns empty docs
+- `personaPath` — points to a temp file with a basic persona
+
+Key behavior to test:
+- Call `agent.chat("test")` with a model mock that returns `reasoning_content: "I thought about this carefully"`
+- The agent's internal history is not directly exposed, but we can verify via a second call: override conversation with the history from a captured mock
+- Alternatively, since `createAgent` doesn't expose history, test the `formatConversation` integration path instead (see Task 4)
+
+A more direct approach: since the agent returns `ChatResult` with only `text` and `stats`, and reasoning is preserved internally, the most valuable test is to verify that a model response with reasoning doesn't break the agent loop and that the text response is correctly extracted. The reasoning preservation is structural (type system enforces it once the field is set).
+
+However, for a proper behavioral test, we can use `conversationOverride` to inject a message with reasoning and verify the model receives it back on subsequent calls. Here's the approach:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+
+// Track what the model receives so we can inspect history
+const receivedMessages: Message[][] = [];
+
+const mockModel = {
+  async complete(request: { messages: ReadonlyArray<Message> }): Promise<ModelResponse> {
+    receivedMessages.push([...request.messages]);
+    return {
+      content: [{ type: 'text', text: 'I have responded.' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 5 },
+      reasoning_content: 'Let me think step by step about this problem.',
+    };
+  },
+};
+```
+
+The full test creates an agent with minimal mocks, calls `chat()`, then calls `chat()` again and inspects the messages sent to the model on the second call. The second call's messages should include the assistant message from the first call, which should have `reasoning_content` set.
+
+**Testing pattern notes:**
+- Bun test runner is used (`bun test`)
+- No existing test files in the codebase, so this establishes the pattern
+- The persona file must exist — use `Bun.write` to create a temp file
+- Store mock needs `docGet`, `docList` methods minimum (used by `loadCoreMemoryFromStore` and skill listing)
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/agent.test.ts`
+Expected: Test passes.
+
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Test — formatConversation includes reasoning
+
+**Verifies:** GH11.AC9.2
+
+**Files:**
+- Create: `src/agent/compaction.test.ts`
+
+**Implementation:**
+
+Test the `formatConversation` function directly. This is a pure function — much easier to test in isolation than the full agent loop.
+
+Problem: `formatConversation` is not exported (it's a module-private function in `compaction.ts`). Two options:
+
+**Option A (preferred):** Export `formatConversation` from `compaction.ts`. It's a pure function with no side effects — there's no reason to hide it, and exporting it enables direct testing.
+
+**Option B:** Test indirectly through `compactContext`, which is exported but requires store + model mocks.
+
+Go with Option A. Add `export` to `formatConversation`:
+
+In `src/agent/compaction.ts`, change line 19 from:
+```typescript
+function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+to:
+```typescript
+export function formatConversation(messages: ReadonlyArray<Message>): string {
+```
+
+Then create the test:
+
+```typescript
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});
+```
+
+**Verification:**
+
+Run: `cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test src/agent/compaction.test.ts`
+Expected: Both tests pass.
+
+**Commit:** `test(GH11): add tests for reasoning_content in agent loop and compaction`
+
+<!-- END_TASK_4 -->
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/11/implementation-plan/test-requirements.md
+++ b/docs/projects/11/implementation-plan/test-requirements.md
@@ -1,0 +1,51 @@
+# GH11: Extended Thinking / Reasoning Content Preservation — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+### Automated Tests
+
+| AC | Description | Test Type | Test File | Notes |
+|----|-------------|-----------|-----------|-------|
+| GH11.AC1.1 | `ModelResponse` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler (`tsc --noEmit`). No runtime test needed. |
+| GH11.AC2.1 | `Message` has `reasoning_content?: string` | Type check | N/A | Verified by TypeScript compiler. No runtime test needed. |
+| GH11.AC3.1 | Anthropic extracts thinking blocks | Type check | N/A | Structural — verified by compiler. Integration testing requires live Anthropic API with extended thinking enabled. |
+| GH11.AC3.2 | Anthropic no-op when no thinking blocks | Type check | N/A | Field is optional, absence is the default. Compiler verifies. |
+| GH11.AC4.1 | OpenRouter extracts reasoning | Type check | N/A | Structural — verified by compiler. Integration testing requires live OpenRouter API with reasoning model. |
+| GH11.AC4.2 | OpenRouter no-op when no reasoning | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC5.1 | OpenAI-compat extracts reasoning_content | Type check | N/A | Structural — verified by compiler. |
+| GH11.AC5.2 | OpenAI-compat no-op when absent | Type check | N/A | Field is optional, absence is the default. |
+| GH11.AC6.1 | Agent loop attaches reasoning to assistant message | Unit | `src/agent/agent.test.ts` | Mock model returns reasoning, verify it appears in history on next model call. |
+| GH11.AC6.2 | Agent loop no-op when reasoning absent | Unit | `src/agent/agent.test.ts` | Mock model returns no reasoning, verify message has no `reasoning_content`. |
+| GH11.AC7.1 | Compaction includes reasoning in formatted output | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` with a message containing `reasoning_content`. |
+| GH11.AC7.2 | Compaction unchanged when no reasoning | Unit | `src/agent/compaction.test.ts` | Direct test of `formatConversation` without `reasoning_content` — output matches prior format. |
+| GH11.AC9.1 | Test: mock model with reasoning, verify on assistant message | Unit | `src/agent/agent.test.ts` | Core behavioral test of the feature. |
+| GH11.AC9.2 | Test: formatConversation includes reasoning | Unit | `src/agent/compaction.test.ts` | Core behavioral test of compaction serialization. |
+
+### Human Verification
+
+| AC | Description | Verification Approach |
+|----|-------------|----------------------|
+| GH11.AC8.1 | No display in TUI | Verify no TUI files were modified. Run `git diff --name-only` after implementation and confirm no files under `src/tui/` appear. |
+| GH11.AC3.1 (integration) | Anthropic thinking blocks extracted in production | Manually test with a Claude model that supports extended thinking. Set `reasoning: high` in config, send a request, inspect debug logs for reasoning content. |
+| GH11.AC4.1 (integration) | OpenRouter reasoning extracted in production | Manually test with an OpenRouter model that returns reasoning. Inspect debug logs. |
+
+## Test Execution
+
+```bash
+# Run all tests
+cd /Users/scarndp/dev/johnson/.worktrees/GH11 && bun test
+
+# Run specific test files
+bun test src/agent/agent.test.ts
+bun test src/agent/compaction.test.ts
+
+# Type checking (covers AC1-AC5 structurally)
+npx tsc --noEmit
+```
+
+## Summary
+
+- **4 automated unit tests** across 2 test files
+- **Type checking** covers the structural correctness of all provider changes (AC1-AC5)
+- **3 human verification items** for TUI non-impact and live integration testing
+- Provider extraction logic (AC3-AC5) is structural — the code either sets the field from the API response or doesn't. The extraction patterns are straightforward conditional reads with no branching logic that warrants mocking the HTTP layer.

--- a/docs/projects/14/design.md
+++ b/docs/projects/14/design.md
@@ -1,0 +1,44 @@
+# #14 — Standalone Secrets Management
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/14
+**Wave:** 0 (no dependencies)
+**Status:** Mostly complete — extending existing implementation
+
+## Current State
+
+`src/secrets/manager.ts` already implements the full `SecretManager` interface:
+- `listKeys()` — sorted array of secret names (never values)
+- `get(key)` — returns value (internal use only — env injection)
+- `set(key, value)` — create/update + persist
+- `remove(key)` — delete + persist
+- `resolve(keys)` — bulk resolve to env var map
+
+Storage: `data/secrets.json` (flat JSON key-value pairs). Already wired into `src/index.ts` and passed to agents via `AgentDependencies`.
+
+## Design
+
+### Change: Make persistence awaitable
+
+Currently `set()` and `remove()` call an internal `save()` that is fire-and-forget (`writeFile` with `.catch(() => {})`). New consumers (TUI secrets screen, custom tools) need to know when persistence completes.
+
+**Change `set()` and `remove()` signatures to return `Promise<void>`.**
+
+Internally, replace the fire-and-forget `save()` with a direct `await writeFile(...)`. The `mkdir` call stays (ensures `data/` exists on first write).
+
+### No other changes needed
+
+- Type is already exported from `src/secrets/index.ts`
+- Already usable by new consumers (web tools, notify tool, custom tools will call `deps.secrets?.get('KEY_NAME')`)
+- TUI secrets screen is #13's responsibility
+
+## Files Touched
+
+- `src/secrets/manager.ts` — make `set`/`remove` return `Promise<void>`
+- New test file for integration test (set/get/remove/resolve, verify JSON on disk)
+
+## Acceptance Criteria
+
+1. `set()` and `remove()` return `Promise<void>`
+2. After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }`
+3. `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys)
+4. Existing callers unaffected (returned promise can be ignored for backward compat)

--- a/docs/projects/14/implementation-plan/phase_01.md
+++ b/docs/projects/14/implementation-plan/phase_01.md
@@ -1,0 +1,306 @@
+# GH14: Standalone Secrets Management — Implementation Plan
+
+**Goal:** Make `SecretManager.set()` and `remove()` return `Promise<void>` so callers can await persistence, and add integration tests verifying the full lifecycle.
+
+**Architecture:** Minimal change to the existing `SecretManager` closure in `src/secrets/manager.ts`. The internal `save()` function becomes async and is awaited by `set()` and `remove()`. The type definition updates accordingly. Existing callers that ignore the return value remain unaffected (returning a `Promise<void>` where `void` was returned before is backward-compatible in TypeScript).
+
+**Tech Stack:** Bun (runtime + test runner), `node:fs/promises`
+
+**Scope:** 1 phase from original design (phase 1 of 1)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH14.AC1: Awaitable persistence
+- **GH14.AC1.1 Success:** `set()` and `remove()` return `Promise<void>`
+
+### GH14.AC2: Persistence correctness
+- **GH14.AC2.1 Success:** After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }`
+
+### GH14.AC3: Resolve behaviour
+- **GH14.AC3.1 Success:** `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys)
+
+### GH14.AC4: Backward compatibility
+- **GH14.AC4.1 Success:** Existing callers unaffected (returned promise can be ignored for backward compat)
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Update `SecretManager` type and implementation for awaitable persistence
+
+**Verifies:** GH14.AC1.1, GH14.AC4.1
+
+**Files:**
+- Modify: `src/secrets/manager.ts`
+
+**Implementation:**
+
+Two changes to `src/secrets/manager.ts`:
+
+**Change 1: Update the `SecretManager` type (lines 17, 19)**
+
+Replace the current synchronous signatures:
+
+```typescript
+/** Set a secret. */
+set(key: string, value: string): void;
+/** Delete a secret. */
+remove(key: string): void;
+```
+
+With async signatures:
+
+```typescript
+/** Set a secret. Resolves when persisted to disk. */
+set(key: string, value: string): Promise<void>;
+/** Delete a secret. Resolves when persisted to disk. */
+remove(key: string): Promise<void>;
+```
+
+**Change 2: Make `save()` awaitable and `set()`/`remove()` async (lines 40-62)**
+
+Replace the current fire-and-forget `save()` and the `set()`/`remove()` methods:
+
+```typescript
+// Current (fire-and-forget):
+function save(): void {
+  mkdir(dirname(path), { recursive: true })
+    .then(() => writeFile(path, JSON.stringify(secrets, null, 2) + '\n'))
+    .catch(() => {});
+}
+
+// ...
+set(key: string, value: string): void {
+  secrets[key] = value;
+  save();
+},
+
+remove(key: string): void {
+  delete secrets[key];
+  save();
+},
+```
+
+With:
+
+```typescript
+async function save(): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(secrets, null, 2) + '\n');
+}
+
+// ...
+async set(key: string, value: string): Promise<void> {
+  secrets[key] = value;
+  await save();
+},
+
+async remove(key: string): Promise<void> {
+  delete secrets[key];
+  await save();
+},
+```
+
+Note: error handling is intentionally removed from `save()`. The design specifies that callers should now see errors rather than swallowing them. If `writeFile` fails, the promise rejects and the caller gets the error. The in-memory state is still updated (consistent with prior behaviour where the in-memory update succeeded even if save failed).
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Builds without errors. The existing callers in `src/tui/ReviewPage.tsx` (lines 170, 195) call `secrets.set()` and `secrets.remove()` without `await` — this is valid TypeScript since ignoring a `Promise<void>` return is permitted.
+
+**Commit:** `feat(secrets): make set() and remove() return Promise<void> for awaitable persistence`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add integration tests for SecretManager lifecycle
+
+**Verifies:** GH14.AC1.1, GH14.AC2.1, GH14.AC3.1, GH14.AC4.1
+
+**Files:**
+- Create: `src/secrets/manager.test.ts`
+
+**Implementation:**
+
+This is the first test file in the project. Uses Bun's built-in test runner (`bun test`), which auto-discovers `*.test.ts` files. Bun's test API uses `describe`, `test`/`it`, and `expect` — no imports needed for these globals (they're injected by the Bun test runner).
+
+Create `src/secrets/manager.test.ts` with these test cases:
+
+```typescript
+// Integration tests for SecretManager — verifies persistence lifecycle against real filesystem.
+
+import { readFileSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSecretManager } from './manager.ts';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+const TEST_DIR = join(import.meta.dir, '../../.test-tmp');
+const TEST_PATH = join(TEST_DIR, 'secrets.json');
+
+function cleanup(): void {
+  try {
+    rmSync(TEST_DIR, { recursive: true });
+  } catch {
+    // ignore if doesn't exist
+  }
+}
+
+describe('SecretManager', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  test('set() persists to JSON file on disk', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ FOO: 'bar' });
+  });
+
+  test('set() returns a Promise', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const result = mgr.set('X', 'Y');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('remove() returns a Promise', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('X', 'Y');
+    const result = mgr.remove('X');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('get() retrieves a previously set value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('TOKEN', 'abc123');
+    expect(mgr.get('TOKEN')).toBe('abc123');
+  });
+
+  test('get() returns undefined for missing keys', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    expect(mgr.get('NONEXISTENT')).toBeUndefined();
+  });
+
+  test('remove() deletes a secret and persists', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('DEL_ME', 'gone');
+    await mgr.remove('DEL_ME');
+
+    expect(mgr.get('DEL_ME')).toBeUndefined();
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({});
+  });
+
+  test('listKeys() returns sorted key names', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('ZEBRA', 'z');
+    await mgr.set('ALPHA', 'a');
+    await mgr.set('MIDDLE', 'm');
+
+    expect(mgr.listKeys()).toEqual(['ALPHA', 'MIDDLE', 'ZEBRA']);
+  });
+
+  test('resolve() returns env map for existing keys, skips missing', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+    await mgr.set('BAZ', 'qux');
+
+    const env = mgr.resolve(['FOO', 'MISSING', 'BAZ']);
+    expect(env).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('resolve() returns empty object when no keys match', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const env = mgr.resolve(['NOTHING', 'NOPE']);
+    expect(env).toEqual({});
+  });
+
+  test('new manager loads persisted secrets from disk', async () => {
+    const mgr1 = createSecretManager(TEST_PATH);
+    await mgr1.set('PERSIST', 'across-instances');
+
+    const mgr2 = createSecretManager(TEST_PATH);
+    expect(mgr2.get('PERSIST')).toBe('across-instances');
+    expect(mgr2.listKeys()).toEqual(['PERSIST']);
+  });
+
+  test('set() overwrites existing value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('KEY', 'old');
+    await mgr.set('KEY', 'new');
+
+    expect(mgr.get('KEY')).toBe('new');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ KEY: 'new' });
+  });
+
+  test('creates parent directory if it does not exist', async () => {
+    const nested = join(TEST_DIR, 'deep', 'nested', 'secrets.json');
+    const mgr = createSecretManager(nested);
+    await mgr.set('DEEP', 'value');
+
+    const raw = readFileSync(nested, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ DEEP: 'value' });
+  });
+
+  test('ignoring returned promise does not throw (backward compat)', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    // Existing callers call set()/remove() without await — this must not throw
+    mgr.set('IGNORED', 'promise');
+    mgr.remove('IGNORED');
+    // If we get here without error, backward compat is satisfied
+  });
+});
+```
+
+**Testing:**
+
+Tests verify each AC:
+- **GH14.AC1.1:** `set()` and `remove()` return `Promise` instances (tested via `toBeInstanceOf(Promise)`)
+- **GH14.AC2.1:** After `await mgr.set('FOO', 'bar')`, reading the file shows `{ FOO: 'bar' }` (tested via `readFileSync` + `JSON.parse`)
+- **GH14.AC3.1:** `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` — skips missing keys (tested directly)
+- **GH14.AC4.1:** Calling `set()`/`remove()` without `await` does not throw (backward compat test)
+
+**Verification:**
+
+Run: `bun test`
+Expected: All tests pass. Output shows discovered `src/secrets/manager.test.ts`.
+
+**Commit:** `test(secrets): add integration tests for SecretManager lifecycle`
+
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Verify build and full test suite
+
+**Files:**
+- None (verification only)
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Builds without errors.
+
+Run: `bun test`
+Expected: All tests pass.
+
+Verify backward compatibility by inspection: confirm that `src/tui/ReviewPage.tsx` still compiles (it calls `secrets.set()` and `secrets.remove()` without `await` at lines 195 and 170 respectively — this is valid because the promise is simply discarded).
+
+**Commit:** No commit needed — this is a verification step.
+
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/14/implementation-plan/test-requirements.md
+++ b/docs/projects/14/implementation-plan/test-requirements.md
@@ -1,0 +1,43 @@
+# GH14: Standalone Secrets Management — Test Requirements
+
+Maps each acceptance criterion to automated tests or human verification.
+
+---
+
+## Automated Tests
+
+All acceptance criteria for GH14 are verifiable via automated tests.
+
+| Criterion | Description | Test Type | Test File | Test Name(s) |
+|-----------|-------------|-----------|-----------|---------------|
+| GH14.AC1.1 | `set()` and `remove()` return `Promise<void>` | Unit | `src/secrets/manager.test.ts` | `set() returns a Promise`, `remove() returns a Promise` |
+| GH14.AC2.1 | After `await manager.set('FOO', 'bar')`, reading `data/secrets.json` shows `{ "FOO": "bar" }` | Integration | `src/secrets/manager.test.ts` | `set() persists to JSON file on disk` |
+| GH14.AC3.1 | `resolve(['FOO', 'MISSING'])` returns `{ FOO: 'bar' }` (skips missing keys) | Unit | `src/secrets/manager.test.ts` | `resolve() returns env map for existing keys, skips missing` |
+| GH14.AC4.1 | Existing callers unaffected (returned promise can be ignored) | Unit | `src/secrets/manager.test.ts` | `ignoring returned promise does not throw (backward compat)` |
+
+## Additional Coverage
+
+These tests go beyond the minimum acceptance criteria to ensure robustness:
+
+| Behaviour | Test File | Test Name |
+|-----------|-----------|-----------|
+| `get()` retrieves set values | `src/secrets/manager.test.ts` | `get() retrieves a previously set value` |
+| `get()` returns undefined for missing keys | `src/secrets/manager.test.ts` | `get() returns undefined for missing keys` |
+| `remove()` deletes and persists | `src/secrets/manager.test.ts` | `remove() deletes a secret and persists` |
+| `listKeys()` returns sorted names | `src/secrets/manager.test.ts` | `listKeys() returns sorted key names` |
+| `resolve()` returns empty for no matches | `src/secrets/manager.test.ts` | `resolve() returns empty object when no keys match` |
+| New instance loads persisted data | `src/secrets/manager.test.ts` | `new manager loads persisted secrets from disk` |
+| `set()` overwrites existing values | `src/secrets/manager.test.ts` | `set() overwrites existing value` |
+| Parent directory auto-created | `src/secrets/manager.test.ts` | `creates parent directory if it does not exist` |
+
+## Human Verification
+
+| Criterion | Verification Approach | Justification |
+|-----------|----------------------|---------------|
+| GH14.AC4.1 | Verify `src/tui/ReviewPage.tsx` compiles — lines 170 and 195 call `secrets.remove()` / `secrets.set()` without `await` | TypeScript build confirms type compatibility, but human should confirm no runtime warnings in TUI usage |
+
+## Test Infrastructure Notes
+
+- This is the first test file in the project. Uses Bun's built-in test runner.
+- Tests use a temp directory (`.test-tmp/` relative to project root) cleaned up in `beforeEach`/`afterEach`.
+- All tests are integration tests against the real filesystem — no mocks needed since `SecretManager` is a thin wrapper around `fs`.

--- a/docs/projects/3/design.md
+++ b/docs/projects/3/design.md
@@ -1,0 +1,133 @@
+# #3 — Multi-Tool Architecture
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/3
+**Wave:** 1 (no hard dependencies, major registry change)
+
+## Current State
+
+Everything routes through a single `execute_code` tool. The model writes TypeScript, the sandbox executes it, and tool calls go through IPC (`tools.*` namespace).
+
+## Key Insight: Keep execute_code as Primary
+
+The sandbox dispatch model has real advantages over native tool_use for the core tools:
+
+- **Batching:** `Promise.allSettled([tools.doc_get(...), tools.doc_search(...)])` in one sandbox call. Native tool_use = two separate API round trips.
+- **Composition:** `doc_search → filter → doc_get each → format → output()` in one call. Native dispatch = multiple LLM round-trips with the model doing glue logic in text.
+- **Token efficiency:** Native tool_use results are full messages in conversation context. Sandbox batching keeps intermediate results out of context.
+- **Consistency:** Two paths to the same thing = the model has to decide which to use, and sometimes picks wrong.
+
+**Do NOT add a parallel native dispatch path for the existing 8 tools** (doc_upsert, doc_get, doc_list, doc_search, run_skill, schedule_task, list_tasks, cancel_task). They stay sandbox-only.
+
+## Design
+
+### Where native tool_use wins
+
+Native dispatch is justified only when:
+
+1. **Result format requires it** — `view_image` needs to return an image content block the model can see. Can't tunnel that through text-only sandbox results.
+2. **Sandbox routing adds no value** — `notify_discord` is fire-and-forget. `summarize` calls a sub-agent LLM and returns text. Neither benefits from batching or composition.
+
+### Selective native tools
+
+These tools get native `tool_use` definitions:
+- `view_image` (#9) — image content blocks
+- `notify_discord` (#6) — fire-and-forget webhook
+- `summarize` (#8) — sub-agent call, no composition value
+
+Everything else stays sandbox-only via `execute_code`.
+
+### Registry Changes (`src/runtime/tool-registry.ts`)
+
+Add a `mode` flag to tool registration:
+
+```typescript
+type ToolMode = 'sandbox' | 'native' | 'both';
+
+type RegistryEntry = {
+  definition: ToolDefinition;
+  handler: ToolHandler;
+  mode: ToolMode;
+};
+```
+
+- `'sandbox'` — available in Deno sandbox via stubs only (existing tools)
+- `'native'` — exposed as API-level tool_use definition only (image, notify, summarize)
+- `'both'` — available in both paths (if needed in future)
+
+New methods:
+- `generateToolDefinitions(): ToolDefinition[]` — returns definitions for tools with mode `'native'` or `'both'`
+- Existing `generateTypeScriptStubs()` — generates stubs for tools with mode `'sandbox'` or `'both'`
+- Existing `generateToolDocumentation()` — documents ALL tools (all modes) for the system prompt
+
+Update `register()` to accept mode (default `'sandbox'` for backward compat).
+
+### Agent Loop Changes (`src/agent/agent.ts`)
+
+Build tools list:
+```typescript
+const nativeTools = registry.generateToolDefinitions();
+const tools = [EXECUTE_CODE_TOOL, ...nativeTools];
+```
+
+Tool dispatch splits on name:
+```typescript
+if (block.name === 'execute_code') {
+  // existing Deno sandbox path — unchanged
+} else {
+  // native tool: dispatch directly through registry
+  const result = await registry.execute(block.name, block.input);
+  // format result for ToolResultBlock
+}
+```
+
+### Tool Result Formatting
+
+Native tool results need to be formatted into `ToolResultBlock`:
+
+- **String results:** Use as-is for `content`
+- **Object results:** `JSON.stringify(result)`
+- **Image results:** Special case — when result has `type: 'image_result'`, format as multi-content-block (text + image block). This requires widening `ToolResultBlock.content`.
+
+### Type Change (`src/model/types.ts`)
+
+Widen `ToolResultBlock.content` from `string` to `string | Array<ContentBlock>`:
+
+```typescript
+type ToolResultBlock = {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string | Array<ContentBlock>;
+  is_error?: boolean;
+};
+```
+
+This enables image content blocks in tool results. Model providers that serialize messages need to handle the array case.
+
+### Backward Compatibility
+
+- All existing tools unchanged — still `mode: 'sandbox'`, still work through `execute_code`
+- `execute_code` tool definition unchanged
+- Deno stubs still generated for sandbox-mode tools
+- System prompt documents all tools regardless of mode
+- New native tools are *also* documented in the system prompt so the model knows about them
+
+## Files Touched
+
+- `src/runtime/tool-registry.ts` — add `mode`, `generateToolDefinitions()`, update `register()` signature
+- `src/agent/agent.ts` — build combined tools list, add native dispatch branch
+- `src/model/types.ts` — widen `ToolResultBlock.content`
+- `src/agent/tools.ts` — no changes (existing tools keep default `mode: 'sandbox'`)
+
+## Acceptance Criteria
+
+1. Registry supports `mode: 'sandbox' | 'native' | 'both'` per tool
+2. `generateToolDefinitions()` returns only native/both-mode tools
+3. `generateTypeScriptStubs()` generates stubs for only sandbox/both-mode tools
+4. `generateToolDocumentation()` documents all tools regardless of mode
+5. Agent loop dispatches native tools directly through registry
+6. Agent loop still dispatches `execute_code` through Deno sandbox
+7. `ToolResultBlock.content` supports `string | Array<ContentBlock>`
+8. Existing tools unaffected — all 8 remain sandbox-only
+9. Test: register native tool → verify it appears in `generateToolDefinitions()` but not in stubs
+10. Test: mock model returns native tool_use → verify registry.execute called directly
+11. Test: mock model returns `execute_code` → verify Deno sandbox path unchanged

--- a/docs/projects/3/implementation-plan/phase_01.md
+++ b/docs/projects/3/implementation-plan/phase_01.md
@@ -1,0 +1,239 @@
+# GH03: Multi-Tool Architecture — Phase 1: Tool Registry Extension
+
+**Goal:** Extend the ToolRegistry to support a `mode` flag per tool entry, enabling selective exposure of tools as native API-level `tool_use` definitions vs sandbox-only stubs.
+
+**Architecture:** Add a `ToolMode` type (`'sandbox' | 'native' | 'both'`) to the registry entry. Update `register()` to accept mode (default `'sandbox'` for backward compatibility). Add `generateToolDefinitions()` that returns definitions for native/both-mode tools. Filter existing `generateTypeScriptStubs()` to sandbox/both-mode tools. `generateToolDocumentation()` continues to document all tools regardless of mode.
+
+**Tech Stack:** TypeScript, Bun
+
+**Scope:** 4 phases from original design (phases 1-4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH03.AC1: Registry supports mode per tool
+- **GH03.AC1.1 Success:** Registry supports `mode: 'sandbox' | 'native' | 'both'` per tool
+- **GH03.AC1.2 Success:** `generateToolDefinitions()` returns only native/both-mode tools
+- **GH03.AC1.3 Success:** `generateTypeScriptStubs()` generates stubs for only sandbox/both-mode tools
+- **GH03.AC1.4 Success:** `generateToolDocumentation()` documents all tools regardless of mode
+- **GH03.AC1.5 Success:** Existing tools unaffected — all 8 remain sandbox-only
+
+### GH03.AC9: Test registry mode filtering
+- **GH03.AC9.1 Success:** Register native tool, verify it appears in `generateToolDefinitions()` but not in stubs
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add ToolMode type and update RegistryEntry
+
+**Files:**
+- Modify: `src/runtime/tool-registry.ts:9-18` (type definitions)
+
+**Implementation:**
+
+Add the `ToolMode` type and update `RegistryEntry` to include it. Export `ToolMode` since the agent loop will need it for type checking.
+
+After the existing `ToolHandler` type (line 13), add:
+
+```typescript
+export type ToolMode = 'sandbox' | 'native' | 'both';
+```
+
+Update the `RegistryEntry` type (lines 15-18) to include mode:
+
+```typescript
+type RegistryEntry = {
+  definition: ToolDefinition;
+  handler: ToolHandler;
+  mode: ToolMode;
+};
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Type check passes (downstream code will have errors until Task 2 completes — that's expected within this subcomponent)
+
+**Commit:** Do not commit yet — complete Task 2 first.
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Update register() signature and ToolRegistry type
+
+**Files:**
+- Modify: `src/runtime/tool-registry.ts:20-33` (ToolRegistry type)
+- Modify: `src/runtime/tool-registry.ts:116-122` (register function implementation)
+
+**Implementation:**
+
+Update the `ToolRegistry` type's `register` method to accept an optional `mode` parameter:
+
+```typescript
+export type ToolRegistry = {
+  register(
+    name: string,
+    definition: ToolDefinition,
+    handler: ToolHandler,
+    mode?: ToolMode,
+  ): void;
+  // ... rest unchanged
+```
+
+Add `generateToolDefinitions()` to the `ToolRegistry` type, after `execute`:
+
+```typescript
+  generateToolDefinitions(): ToolDefinition[];
+```
+
+Update the `register` function implementation to accept and store mode (defaulting to `'sandbox'`):
+
+```typescript
+function register(
+  name: string,
+  definition: ToolDefinition,
+  handler: ToolHandler,
+  mode: ToolMode = 'sandbox',
+): void {
+  entries.set(name, { definition, handler, mode });
+}
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Errors about missing `generateToolDefinitions` in return object (fixed in Task 3)
+
+**Commit:** Do not commit yet — complete Task 3 first.
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Implement generateToolDefinitions() and add mode filtering
+
+**Files:**
+- Modify: `src/runtime/tool-registry.ts:154-175` (generateTypeScriptStubs)
+- Modify: `src/runtime/tool-registry.ts:181-209` (generateToolDocumentation)
+- Modify: `src/runtime/tool-registry.ts:211-219` (return object)
+
+**Implementation:**
+
+Add the `generateToolDefinitions()` function inside `createToolRegistry()`, before the return statement. This returns `ToolDefinition[]` for tools with mode `'native'` or `'both'`:
+
+```typescript
+function generateToolDefinitions(): ToolDefinition[] {
+  const definitions: ToolDefinition[] = [];
+  for (const [, entry] of entries) {
+    if (entry.mode === 'native' || entry.mode === 'both') {
+      definitions.push(entry.definition);
+    }
+  }
+  return definitions;
+}
+```
+
+Update `generateTypeScriptStubs()` to filter entries to only sandbox/both-mode tools. Change the loop at line 161 from:
+
+```typescript
+for (const [name, entry] of entries) {
+```
+
+to:
+
+```typescript
+for (const [name, entry] of entries) {
+  if (entry.mode === 'native') continue;
+```
+
+`generateToolDocumentation()` requires NO changes — it already documents all entries, which is the desired behaviour.
+
+Add `generateToolDefinitions` to the return object:
+
+```typescript
+return {
+  register,
+  get,
+  list,
+  execute,
+  generateToolDefinitions,
+  generateTypeScriptStubs,
+  generateToolDocumentation,
+};
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors. All existing callers of `register()` still work because `mode` defaults to `'sandbox'`.
+
+**Commit:**
+```bash
+git add src/runtime/tool-registry.ts
+git commit -m "feat(registry): add ToolMode and generateToolDefinitions for native tool support"
+```
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 4-5) -->
+
+<!-- START_TASK_4 -->
+### Task 4: Write ToolRegistry mode filtering tests
+
+**Verifies:** GH03.AC1.1, GH03.AC1.2, GH03.AC1.3, GH03.AC1.4, GH03.AC1.5, GH03.AC9.1
+
+**Files:**
+- Create: `src/runtime/tool-registry.test.ts`
+
+**Implementation:**
+
+Create the first test file in the project. Bun's test runner discovers `*.test.ts` files automatically. No configuration needed.
+
+The test file should import `createToolRegistry` and exercise the mode filtering. Define a small helper to create a dummy `ToolDefinition` with a given name.
+
+**Testing:**
+Tests must verify each AC listed above:
+- **GH03.AC1.1:** Register tools with each mode value (`'sandbox'`, `'native'`, `'both'`) — verify they are stored and retrievable via `get()`.
+- **GH03.AC1.2:** Register one sandbox tool, one native tool, one both-mode tool. Call `generateToolDefinitions()` — verify it returns only the native and both-mode tools (not the sandbox-only tool).
+- **GH03.AC1.3:** Same setup. Call `generateTypeScriptStubs()` — verify the output contains stub functions for sandbox and both-mode tools, but NOT for the native-only tool.
+- **GH03.AC1.4:** Same setup. Call `generateToolDocumentation()` — verify all three tools appear in the output regardless of mode.
+- **GH03.AC1.5:** Register a tool with no explicit mode (relies on default). Verify via `get()` that it has mode `'sandbox'`. Verify it appears in stubs and docs, but not in `generateToolDefinitions()`.
+- **GH03.AC9.1:** Register a native-mode tool. Verify it appears in `generateToolDefinitions()`. Verify it does NOT appear in `generateTypeScriptStubs()` output.
+
+Follow Bun test conventions: `import { describe, it, expect } from 'bun:test'`.
+
+**Verification:**
+Run: `bun test src/runtime/tool-registry.test.ts`
+Expected: All tests pass
+
+**Commit:**
+```bash
+git add src/runtime/tool-registry.test.ts
+git commit -m "test(registry): add mode filtering tests for ToolRegistry"
+```
+<!-- END_TASK_4 -->
+
+<!-- START_TASK_5 -->
+### Task 5: Verify existing tools are unaffected
+
+**Verifies:** GH03.AC1.5
+
+**Implementation:**
+
+This is a manual verification step. The existing `createAgentTools()` in `src/agent/tools.ts` calls `registry.register(name, definition, handler)` for all 8 tools without a `mode` argument. Since `mode` defaults to `'sandbox'`, all existing tools remain sandbox-only.
+
+Verify by reading `src/agent/tools.ts` and confirming none of the 8 `register()` calls pass a 4th argument. Confirm that `bunx tsc --noEmit` passes with zero errors.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No errors. All 8 existing tool registrations compile without changes.
+
+Run: `bun test`
+Expected: All tests pass (including the new ones from Task 4).
+
+**Commit:** No commit needed — this is a verification-only step.
+<!-- END_TASK_5 -->
+
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/3/implementation-plan/phase_02.md
+++ b/docs/projects/3/implementation-plan/phase_02.md
@@ -1,0 +1,286 @@
+# GH03: Multi-Tool Architecture — Phase 2: Widen ToolResultBlock Content Type
+
+**Goal:** Widen `ToolResultBlock.content` from `string` to `string | Array<ContentBlock>` so native tools can return rich content (e.g., image content blocks) in tool results.
+
+**Architecture:** Change the type in `src/model/types.ts`, then update all 4 model providers and the 2 context-handling modules that read `block.content` to handle the new union type. For OpenAI-compat and OpenRouter providers, array content is serialized to JSON string since those APIs only accept string tool results. The Anthropic provider already passes content through to the SDK, which natively supports array content.
+
+**Tech Stack:** TypeScript, Bun
+
+**Scope:** 4 phases from original design (phases 1-4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH03.AC7: ToolResultBlock content type
+- **GH03.AC7.1 Success:** `ToolResultBlock.content` supports `string | Array<ContentBlock>`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-4) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Widen ToolResultBlock.content type
+
+**Files:**
+- Modify: `src/model/types.ts:15-20`
+
+**Implementation:**
+
+Change the `ToolResultBlock` type. The `content` field changes from `string` to `string | Array<ContentBlock>`.
+
+Because `ContentBlock` is defined AFTER `ToolResultBlock` in the file (line 27), and `ContentBlock` includes `ToolResultBlock`, this creates a circular reference. TypeScript handles this fine for type aliases in the same file — forward references work. But to be safe, define a dedicated `ToolResultContent` type for the union members that can appear inside a tool result (text and image blocks only — not `ToolUseBlock` or `ToolResultBlock` themselves):
+
+```typescript
+export type ToolResultContentBlock = TextBlock | ImageBlock;
+
+export type ToolResultBlock = {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string | Array<ToolResultContentBlock>;
+  is_error?: boolean;
+};
+```
+
+This avoids the circular reference entirely and is more precise — a tool result's array content should only contain text and image blocks, never nested tool_use or tool_result blocks.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Type errors in files that assume `content` is always `string`. These will be fixed in subsequent tasks.
+
+**Commit:** Do not commit yet — complete the rest of this subcomponent first.
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add content serialization helper
+
+**Files:**
+- Modify: `src/model/types.ts` (add at end of file)
+
+**Implementation:**
+
+Add a pure helper function that serializes `ToolResultBlock.content` to a plain string. This is used by model providers that only accept string content for tool results (OpenRouter, OpenAI-compat, Ollama).
+
+```typescript
+/**
+ * Serialize ToolResultBlock content to a plain string.
+ * If content is already a string, return as-is.
+ * If content is an array of content blocks, extract text parts and join them.
+ * Image blocks are represented as '[image]' placeholders.
+ */
+export function toolResultContentToString(
+  content: string | Array<ToolResultContentBlock>,
+): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => {
+      if (block.type === 'text') return block.text;
+      if (block.type === 'image_url') return '[image]';
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Same type errors as before (providers not yet updated). The helper itself should compile.
+
+**Commit:** Do not commit yet.
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Update model providers to handle widened content type
+
+**Files:**
+- Modify: `src/model/openrouter.ts:80-85` and `src/model/openrouter.ts:96-100`
+- Modify: `src/model/openai-compat.ts:114-119` and `src/model/openai-compat.ts:131-134`
+- Modify: `src/model/ollama.ts:103-107`
+- Modify: `src/model/anthropic.ts` (no changes needed — passes through to SDK)
+
+**Implementation:**
+
+Import `toolResultContentToString` from `../model/types.ts` in the three providers that serialize tool results to strings.
+
+**openrouter.ts** — Two locations where `block.content` is used as tool result content:
+
+Line 83 (inside `hasImages` branch):
+```typescript
+} else if (block.type === 'tool_result') {
+  result.push({
+    role: 'tool',
+    toolCallId: block.tool_use_id,
+    content: toolResultContentToString(block.content),
+  });
+}
+```
+
+Line 99 (inside the else branch):
+```typescript
+} else if (block.type === 'tool_result') {
+  result.push({
+    role: 'tool',
+    toolCallId: block.tool_use_id,
+    content: toolResultContentToString(block.content),
+  });
+}
+```
+
+**openai-compat.ts** — Two locations:
+
+Line 117 (inside `hasImages` branch):
+```typescript
+} else if (block.type === 'tool_result') {
+  toolResults.push({
+    role: 'tool',
+    tool_call_id: block.tool_use_id,
+    content: toolResultContentToString(block.content),
+  });
+}
+```
+
+Line 134 (inside the else branch):
+```typescript
+} else if (block.type === 'tool_result') {
+  result.push({
+    role: 'tool',
+    tool_call_id: block.tool_use_id,
+    content: toolResultContentToString(block.content),
+  });
+}
+```
+
+**ollama.ts** — One location:
+
+Line 105:
+```typescript
+} else if (block.type === 'tool_result') {
+  result.push({
+    role: 'tool',
+    content: toolResultContentToString(block.content),
+  });
+}
+```
+
+**anthropic.ts** — No changes needed. The Anthropic provider passes `m.content` directly to the SDK via a type cast (line 50: `content: m.content as Anthropic.MessageCreateParams['messages'][number]['content']`). The Anthropic SDK natively supports array content in tool results, so widening our type aligns with their API.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Remaining errors only in `src/agent/context.ts` (fixed in Task 4).
+
+**Commit:** Do not commit yet.
+<!-- END_TASK_3 -->
+
+<!-- START_TASK_4 -->
+### Task 4: Update context.ts and compaction.ts for widened type
+
+**Files:**
+- Modify: `src/agent/context.ts:161-175` (trimOldToolResults)
+- Modify: `src/agent/compaction.ts:30` (formatConversation)
+
+**Implementation:**
+
+**context.ts — `trimOldToolResults()`:**
+
+The function at line 163 does `typeof content !== 'string'` and skips if not a string. After widening, `content` can be an array. The existing skip logic is actually fine for the trimming purpose — if content is already an array (rich content), we don't want to trim it to a placeholder. But we should still handle it for consistency.
+
+Update the block starting at line 161:
+
+```typescript
+if (block.type !== 'tool_result') continue;
+
+const content = block.content;
+
+// Array content (rich results like images) — skip trimming
+if (typeof content !== 'string') continue;
+
+// Skip if already trimmed or small
+if (content.startsWith('[tool result:') || content.length < 200) continue;
+```
+
+This is actually the same logic that exists today — `typeof content !== 'string'` already guards correctly. The only change is that TypeScript now knows `content` can legitimately be an array, so the guard no longer looks like dead code. No functional change needed, but add a clarifying comment.
+
+**compaction.ts — `formatConversation()`:**
+
+Line 30 does `block.content?.toString().slice(0, 200)`. After widening, if `content` is an array, `toString()` would produce `[object Object],[object Object]` which is useless.
+
+Import `toolResultContentToString` and update line 30:
+
+```typescript
+if (block.type === 'tool_result') return `[tool_result: ${toolResultContentToString(block.content).slice(0, 200)}]`;
+```
+
+Add the import at the top of `compaction.ts`:
+
+```typescript
+import { toolResultContentToString } from '../model/types.ts';
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Zero type errors across the entire project.
+
+Run: `bun test`
+Expected: All existing tests pass.
+
+**Commit:**
+```bash
+git add src/model/types.ts src/model/openrouter.ts src/model/openai-compat.ts src/model/ollama.ts src/agent/context.ts src/agent/compaction.ts
+git commit -m "feat(types): widen ToolResultBlock.content to support array content blocks"
+```
+<!-- END_TASK_4 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_SUBCOMPONENT_B (tasks 5-6) -->
+
+<!-- START_TASK_5 -->
+### Task 5: Write tests for toolResultContentToString helper
+
+**Verifies:** GH03.AC7.1
+
+**Files:**
+- Create: `src/model/types.test.ts`
+
+**Testing:**
+Tests must verify:
+- **GH03.AC7.1 (string path):** Pass a plain string — returns same string.
+- **GH03.AC7.1 (array with text):** Pass an array with text blocks — returns joined text.
+- **GH03.AC7.1 (array with image):** Pass an array with an image block — returns `'[image]'` placeholder.
+- **GH03.AC7.1 (mixed array):** Pass an array with text + image blocks — returns text with `'[image]'` placeholder joined by newlines.
+- **GH03.AC7.1 (empty array):** Pass empty array — returns empty string.
+
+**Verification:**
+Run: `bun test src/model/types.test.ts`
+Expected: All tests pass.
+
+**Commit:**
+```bash
+git add src/model/types.test.ts
+git commit -m "test(types): add toolResultContentToString tests"
+```
+<!-- END_TASK_5 -->
+
+<!-- START_TASK_6 -->
+### Task 6: Verify type-check passes project-wide
+
+**Implementation:**
+
+Run full type check and full test suite to confirm nothing is broken.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Zero errors.
+
+Run: `bun test`
+Expected: All tests pass.
+
+**Commit:** No commit needed — verification only.
+<!-- END_TASK_6 -->
+
+<!-- END_SUBCOMPONENT_B -->

--- a/docs/projects/3/implementation-plan/phase_03.md
+++ b/docs/projects/3/implementation-plan/phase_03.md
@@ -1,0 +1,275 @@
+# GH03: Multi-Tool Architecture — Phase 3: Agent Loop Native Dispatch
+
+**Goal:** Update the agent loop to build a combined tools list (execute_code + native tools from registry) and dispatch native tool calls directly through the registry instead of through the Deno sandbox.
+
+**Architecture:** The agent loop currently hardcodes `tools: [EXECUTE_CODE_TOOL]` when calling the model. After this phase, it builds the list as `[EXECUTE_CODE_TOOL, ...registry.generateToolDefinitions()]`. When the model returns a `tool_use` block, the dispatch logic checks the tool name: `execute_code` goes through the existing Deno sandbox path (unchanged), any other name goes directly to `registry.execute()`. A `formatNativeToolResult()` helper converts the registry handler's return value into a `ToolResultBlock`.
+
+**Tech Stack:** TypeScript, Bun
+
+**Scope:** 4 phases from original design (phases 1-4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH03.AC5: Agent loop dispatches native tools directly
+- **GH03.AC5.1 Success:** Agent loop dispatches native tools directly through registry
+
+### GH03.AC6: Agent loop still dispatches execute_code through Deno sandbox
+- **GH03.AC6.1 Success:** Agent loop still dispatches `execute_code` through Deno sandbox
+
+### GH03.AC8: Existing tools unaffected
+- **GH03.AC8.1 Success:** Existing tools unaffected — all 8 remain sandbox-only
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add formatNativeToolResult helper
+
+**Files:**
+- Modify: `src/agent/agent.ts` (add helper function before `createAgent`)
+
+**Implementation:**
+
+Add a helper function that converts the return value of a native tool handler into a `ToolResultBlock`. This handles three cases:
+
+1. **String result** — use directly as content.
+2. **Object with `type: 'image_result'`** — format as an array of content blocks (text + image). This is the convention for tools like `view_image` (GH09) that return image data.
+3. **Any other object** — JSON.stringify it.
+
+Add the following imports at the top of the file (some may already be imported):
+
+```typescript
+import type { ToolResultContentBlock } from '../model/types.ts';
+```
+
+Add the helper before `createAgent()`:
+
+```typescript
+function formatNativeToolResult(
+  toolUseId: string,
+  result: unknown,
+): ToolResultBlock {
+  // String results pass through directly
+  if (typeof result === 'string') {
+    return { type: 'tool_result', tool_use_id: toolUseId, content: result };
+  }
+
+  // Image results get formatted as array content blocks
+  if (
+    result !== null &&
+    typeof result === 'object' &&
+    'type' in result &&
+    (result as Record<string, unknown>).type === 'image_result'
+  ) {
+    const r = result as Record<string, unknown>;
+    const blocks: Array<ToolResultContentBlock> = [];
+
+    if (typeof r.text === 'string') {
+      blocks.push({ type: 'text', text: r.text });
+    }
+
+    if (r.image && typeof r.image === 'object') {
+      const img = r.image as Record<string, unknown>;
+      if (typeof img.data === 'string' && typeof img.media_type === 'string') {
+        const dataUri = `data:${img.media_type};base64,${img.data}`;
+        blocks.push({ type: 'image_url', image_url: { url: dataUri } });
+      }
+    }
+
+    if (blocks.length > 0) {
+      return { type: 'tool_result', tool_use_id: toolUseId, content: blocks };
+    }
+  }
+
+  // Default: JSON stringify
+  const serialized = typeof result === 'undefined' ? '(no output)' : JSON.stringify(result);
+  return { type: 'tool_result', tool_use_id: toolUseId, content: serialized };
+}
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Compiles. The helper is not called yet.
+
+**Commit:** Do not commit yet — complete Task 2 first.
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Build combined tools list and add native dispatch branch
+
+**Files:**
+- Modify: `src/agent/agent.ts:148-232` (tool loop section)
+
+**Implementation:**
+
+Two changes to the agent loop:
+
+**Change 1: Build combined tools list**
+
+At line 154, the model call currently uses `tools: [EXECUTE_CODE_TOOL]`. Change this to include native tool definitions from the registry:
+
+```typescript
+const nativeTools = registry.generateToolDefinitions();
+```
+
+Add this line after the registry is created (around line 86-90). Then update the model call at line 154:
+
+```typescript
+response = await deps.model.complete({
+  system: systemPrompt,
+  messages: history,
+  tools: [EXECUTE_CODE_TOOL, ...nativeTools],
+  model: deps.config.model,
+  max_tokens: deps.config.maxTokens,
+  temperature: deps.config.temperature,
+  timeout: deps.config.modelTimeout,
+});
+```
+
+**Change 2: Split dispatch on tool name**
+
+Currently, all tool_use blocks are assumed to be `execute_code` and dispatched through the Deno sandbox. After this change, the dispatch checks the tool name first.
+
+Replace the `toolUseBlocks.map(...)` block (lines 201-222) with logic that handles both paths:
+
+```typescript
+const toolResults: Array<ToolResultBlock> = await Promise.all(
+  toolUseBlocks.map(async (block): Promise<ToolResultBlock> => {
+    try {
+      if (block.name === 'execute_code') {
+        // Existing sandbox dispatch path — unchanged
+        const code = (block.input as Record<string, unknown>)['code'];
+        if (typeof code !== 'string') {
+          return { type: 'tool_result', tool_use_id: block.id, content: 'Error: missing code parameter', is_error: true };
+        }
+
+        const onToolCall = async (name: string, params: Record<string, unknown>): Promise<unknown> => {
+          return registry.execute(name, params);
+        };
+
+        const result = await deps.runtime.execute(code, undefined, onToolCall);
+        const output = result.success
+          ? result.output || '(no output)'
+          : `Error: ${result.error ?? 'unknown error'}\n${result.output}`;
+        return { type: 'tool_result', tool_use_id: block.id, content: output, is_error: !result.success };
+      } else {
+        // Native tool dispatch — call registry directly
+        const result = await registry.execute(block.name, block.input);
+        return formatNativeToolResult(block.id, result);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { type: 'tool_result', tool_use_id: block.id, content: `Tool error: ${message}`, is_error: true };
+    }
+  }),
+);
+```
+
+The key structural change: the `execute_code` path is now inside an `if (block.name === 'execute_code')` branch. The `else` branch dispatches native tools directly through the registry. The catch block at the end handles errors from both paths identically.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Zero type errors.
+
+**Commit:**
+```bash
+git add src/agent/agent.ts
+git commit -m "feat(agent): add native tool dispatch alongside execute_code sandbox path"
+```
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Update system prompt tool documentation for native tools
+
+**Files:**
+- Modify: `src/agent/context.ts:55-57` (tool docs section of buildSystemPrompt)
+
+**Implementation:**
+
+Currently, the system prompt says tools are available "only inside TypeScript code you run via `execute_code`". Once native tools exist, this framing is incomplete. Native tools are called directly by the model — they don't go through `execute_code`.
+
+The `generateToolDocumentation()` method in the registry already documents all tools. However, the framing text in `buildSystemPrompt()` (lines 55-57 in `context.ts`) wraps all tool docs under the "tools namespace" heading, which implies they're all sandbox-only.
+
+The solution: `generateToolDocumentation()` should indicate which tools are native vs sandbox. Update `src/runtime/tool-registry.ts` `generateToolDocumentation()` to annotate native tools differently:
+
+In `generateToolDocumentation()`, after the line `sections.push(`### \`tools.${name}\``);`, check the entry's mode. For native/both-mode tools, use a different heading:
+
+```typescript
+function generateToolDocumentation(): string {
+  const sections: string[] = ["## Available Tools", ""];
+
+  for (const [name, entry] of entries) {
+    const def = entry.definition;
+
+    if (entry.mode === 'native' || entry.mode === 'both') {
+      sections.push(`### \`${name}\` *(direct tool call)*`);
+      sections.push("");
+      if (entry.mode === 'both') {
+        sections.push(`> Available as both a direct tool call and via \`tools.${name}()\` in execute_code.`);
+      } else {
+        sections.push(`> Call this tool directly — do NOT use execute_code for this tool.`);
+      }
+      sections.push("");
+    } else {
+      sections.push(`### \`tools.${name}\``);
+      sections.push("");
+    }
+
+    sections.push(def.description);
+    sections.push("");
+
+    const schema = def.input_schema as JsonSchemaObject;
+    const properties = schema.properties;
+    if (properties && Object.keys(properties).length > 0) {
+      const requiredSet = new Set<string>(schema.required ?? []);
+      sections.push("**Parameters:**");
+      sections.push("");
+
+      for (const [paramName, prop] of Object.entries(properties)) {
+        const required = requiredSet.has(paramName) ? " *(required)*" : " *(optional)*";
+        const tsType = jsonSchemaTypeToTs(prop);
+        const desc = prop.description ? ` — ${prop.description}` : "";
+        sections.push(`- \`${paramName}\`: \`${tsType}\`${required}${desc}`);
+      }
+      sections.push("");
+    }
+  }
+
+  return sections.join("\n");
+}
+```
+
+Also update the framing text in `buildSystemPrompt()` in `src/agent/context.ts`. Change lines 55-56 from:
+
+```typescript
+sections.push('\n\n## `tools` Namespace Reference\n\nThe following methods are available on the `tools` object **only inside TypeScript code you run via `execute_code`.** They are NOT callable as top-level functions. To use any of these, emit an `execute_code` tool call with TypeScript that does `await tools.<method>({...})`.\n');
+```
+
+to:
+
+```typescript
+sections.push('\n\n## Tool Reference\n\nTools marked with `tools.<name>` are available **only inside TypeScript code you run via `execute_code`.** Call them as `await tools.<method>({...})`. Tools marked *(direct tool call)* are called directly — do NOT use execute_code for those.\n');
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Zero type errors.
+
+Run: `bun test`
+Expected: All tests pass. Existing registry tests that check `generateToolDocumentation()` output may need their expected strings updated if they check for `tools.<name>` prefix — review and adjust if needed.
+
+**Commit:**
+```bash
+git add src/runtime/tool-registry.ts src/agent/context.ts
+git commit -m "feat(prompt): differentiate native vs sandbox tools in system prompt documentation"
+```
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/3/implementation-plan/phase_04.md
+++ b/docs/projects/3/implementation-plan/phase_04.md
@@ -1,0 +1,164 @@
+# GH03: Multi-Tool Architecture — Phase 4: Integration Tests
+
+**Goal:** Verify the full multi-tool dispatch pipeline works end-to-end: native tools dispatch through the registry, execute_code still dispatches through the Deno sandbox, and the two paths coexist correctly.
+
+**Architecture:** Integration tests use mock model providers and mock runtimes to simulate the agent loop without real LLM calls or Deno subprocesses. Tests verify dispatch routing, result formatting, and error handling for both native and sandbox tool paths.
+
+**Tech Stack:** TypeScript, Bun test runner
+
+**Scope:** 4 phases from original design (phases 1-4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements and tests:
+
+### GH03.AC5: Agent loop dispatches native tools directly
+- **GH03.AC5.1 Success:** Agent loop dispatches native tools directly through registry
+
+### GH03.AC6: Agent loop still dispatches execute_code through Deno sandbox
+- **GH03.AC6.1 Success:** Agent loop still dispatches `execute_code` through Deno sandbox
+
+### GH03.AC10: Mock model returns native tool_use, registry.execute called directly
+- **GH03.AC10.1 Success:** Mock model returns native tool_use → verify registry.execute called directly
+
+### GH03.AC11: Mock model returns execute_code, Deno sandbox path unchanged
+- **GH03.AC11.1 Success:** Mock model returns `execute_code` → verify Deno sandbox path unchanged
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Create test helpers for agent loop testing
+
+**Files:**
+- Create: `src/agent/agent.test.ts`
+
+**Implementation:**
+
+The agent loop (`createAgent`) requires `AgentDependencies`. For testing, build mock implementations of each dependency.
+
+Key mocks needed:
+
+1. **Mock ModelProvider** — Returns predefined responses. Must support multiple rounds (first call returns tool_use, second call returns end_turn with text). The mock should be configurable with a sequence of responses.
+
+2. **Mock CodeRuntime** — Records calls and returns predefined `ExecutionResult`. Used to verify `execute_code` dispatch goes through the sandbox.
+
+3. **Mock Store** — Minimal implementation that satisfies the Store interface. Needs `docGet()` (return null for `self`), `docList()` (return empty), `docUpsert()` (no-op), and grant methods. Since `Store` is from `bun:sqlite`, the simplest approach is to create an in-memory SQLite database using the real `createStore()` — this avoids mocking the entire Store interface.
+
+4. **Mock persona file** — Write a temp file with minimal persona text. The agent reads `deps.personaPath` as a file path.
+
+5. **Mock ToolRegistry override** — For tests that need to register native tools, the test creates its own registry via `createAgentTools()` won't work (it needs real deps). Instead, test the dispatch logic by:
+   - Creating a real agent with mocked deps
+   - Having the mock model return a tool_use block with a native tool name
+   - Registering a native tool handler in the agent's tool creation path
+
+   Since `createAgentTools()` is called inside `_chatImpl`, the test cannot directly inject tools. The cleaner approach: test `formatNativeToolResult` and the dispatch routing separately from the full agent loop.
+
+For the full agent loop test, the mock model should return tool_use blocks. The dispatch routing in the agent checks `block.name === 'execute_code'` — any other name goes to `registry.execute()`. Since the registry only has sandbox-mode tools registered by `createAgentTools()`, calling a name that doesn't exist in the registry will throw. The test should verify:
+- `execute_code` tool_use blocks go through `deps.runtime.execute()`
+- Non-`execute_code` tool_use blocks go through `registry.execute()` (which throws for unknown tools — confirming the path is taken)
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: Test file compiles.
+
+**Commit:** Do not commit yet.
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Write agent loop dispatch routing tests
+
+**Verifies:** GH03.AC5.1, GH03.AC6.1, GH03.AC10.1, GH03.AC11.1
+
+**Files:**
+- Modify: `src/agent/agent.test.ts`
+
+**Testing:**
+Tests must verify each AC:
+
+- **GH03.AC6.1 / GH03.AC11.1 (execute_code path):** Create agent with mock model that returns a tool_use block with `name: 'execute_code'` and `input: { code: 'output("hello")' }` on the first call, then returns an end_turn text response on the second call. Mock runtime's `execute()` should return `{ success: true, output: 'hello', error: null, duration_ms: 1 }`. Verify that `runtime.execute` was called with the code string. Verify the final chat result contains text from the model's second response.
+
+- **GH03.AC5.1 / GH03.AC10.1 (native tool path):** Create agent with mock model that returns a tool_use block with `name: 'some_native_tool'` on the first call, then returns an end_turn text response on the second call. Since `some_native_tool` is not registered in the registry, `registry.execute()` will throw `"Unknown tool: some_native_tool"`. Verify the tool result message contains the error `"Tool error: Unknown tool: some_native_tool"`. This confirms the native dispatch path was taken (not the sandbox path). Additionally, verify that `runtime.execute` was NOT called — confirming the tool did not go through the Deno sandbox.
+
+- **GH03.AC10.1 (native tool success path):** To test a successful native tool dispatch end-to-end, the approach depends on how `createAgentTools` works. Since the test controls `deps`, and `createAgentTools` is called inside `_chatImpl` with those deps, the simplest route is to verify via the error path (above) that native routing works. For a positive test, consider testing `formatNativeToolResult` directly (it's a module-level function — may need to be exported for testing, or test it indirectly through the agent).
+
+**Verification:**
+Run: `bun test src/agent/agent.test.ts`
+Expected: All tests pass.
+
+**Commit:** Do not commit yet.
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Write formatNativeToolResult tests
+
+**Verifies:** GH03.AC5.1, GH03.AC7.1
+
+**Files:**
+- Modify: `src/agent/agent.ts` (export `formatNativeToolResult` for testing)
+- Modify: `src/agent/agent.test.ts` (add tests)
+
+**Implementation:**
+
+Export `formatNativeToolResult` from `agent.ts` so it can be tested directly. Change from:
+
+```typescript
+function formatNativeToolResult(
+```
+
+to:
+
+```typescript
+export function formatNativeToolResult(
+```
+
+**Testing:**
+Tests must verify:
+
+- **String result:** `formatNativeToolResult('id1', 'hello')` returns `{ type: 'tool_result', tool_use_id: 'id1', content: 'hello' }`.
+- **Object result:** `formatNativeToolResult('id1', { key: 'value' })` returns content as `JSON.stringify({ key: 'value' })`.
+- **Undefined result:** Returns content `'(no output)'`.
+- **Image result:** `formatNativeToolResult('id1', { type: 'image_result', text: 'An image', image: { data: 'base64data', media_type: 'image/png' } })` returns content as an array with a text block and an image_url block whose URL is a data URI.
+- **Image result with missing image:** `formatNativeToolResult('id1', { type: 'image_result', text: 'An image' })` returns content as an array with just the text block (no image block since image data is missing).
+
+**Verification:**
+Run: `bun test src/agent/agent.test.ts`
+Expected: All tests pass.
+
+Run: `bun test`
+Expected: All tests across the project pass.
+
+**Commit:**
+```bash
+git add src/agent/agent.ts src/agent/agent.test.ts
+git commit -m "test(agent): add integration tests for native tool dispatch and result formatting"
+```
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->
+
+<!-- START_TASK_4 -->
+### Task 4: Final verification
+
+**Implementation:**
+
+Run the full type check and test suite to confirm everything works together.
+
+**Verification:**
+
+Run: `bunx tsc --noEmit`
+Expected: Zero type errors.
+
+Run: `bun test`
+Expected: All tests pass.
+
+Run: `bun run build`
+Expected: Build succeeds.
+
+**Commit:** No commit needed — verification only.
+<!-- END_TASK_4 -->

--- a/docs/projects/3/implementation-plan/test-requirements.md
+++ b/docs/projects/3/implementation-plan/test-requirements.md
@@ -1,0 +1,30 @@
+# GH03: Multi-Tool Architecture — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+| AC ID | Criterion | Test Type | Test File | Phase |
+|-------|-----------|-----------|-----------|-------|
+| GH03.AC1.1 | Registry supports `mode: 'sandbox' \| 'native' \| 'both'` per tool | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC1.2 | `generateToolDefinitions()` returns only native/both-mode tools | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC1.3 | `generateTypeScriptStubs()` generates stubs for only sandbox/both-mode tools | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC1.4 | `generateToolDocumentation()` documents all tools regardless of mode | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC1.5 | Existing tools unaffected — all 8 remain sandbox-only | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC5.1 | Agent loop dispatches native tools directly through registry | Integration | `src/agent/agent.test.ts` | 4 |
+| GH03.AC6.1 | Agent loop still dispatches `execute_code` through Deno sandbox | Integration | `src/agent/agent.test.ts` | 4 |
+| GH03.AC7.1 | `ToolResultBlock.content` supports `string \| Array<ContentBlock>` | Unit | `src/model/types.test.ts` | 2 |
+| GH03.AC9.1 | Register native tool → appears in `generateToolDefinitions()` but not in stubs | Unit | `src/runtime/tool-registry.test.ts` | 1 |
+| GH03.AC10.1 | Mock model returns native tool_use → registry.execute called directly | Integration | `src/agent/agent.test.ts` | 4 |
+| GH03.AC11.1 | Mock model returns `execute_code` → Deno sandbox path unchanged | Integration | `src/agent/agent.test.ts` | 4 |
+
+## Human Verification Required
+
+| AC ID | Criterion | Justification | Verification Approach |
+|-------|-----------|---------------|----------------------|
+| GH03.AC8.1 | Existing tools unaffected — all 8 remain sandbox-only | Requires reading `src/agent/tools.ts` and confirming no mode arguments added. Partially covered by AC1.5 unit test (default mode is sandbox), but full verification requires human review that no `register()` calls were changed. | Inspect `src/agent/tools.ts` — confirm all `register()` calls have 3 arguments (no 4th `mode` arg). Run `bun start` and verify basic agent functionality (document operations, skill listing) still works. |
+
+## Test Infrastructure Notes
+
+- **Test runner:** Bun's built-in test runner (`bun test`). Discovers `*.test.ts` files automatically.
+- **No existing tests:** This feature introduces the first test files to the project. Tests use `import { describe, it, expect } from 'bun:test'`.
+- **No mocking framework:** Use manual mock implementations. Bun supports `mock()` from `bun:test` for function mocking if needed.
+- **Integration tests:** Agent loop tests require mock `ModelProvider`, `CodeRuntime`, and `Store`. Use an in-memory SQLite database (via the real `createStore()`) for the Store mock to avoid mocking the full interface. Write temp files for persona path.

--- a/docs/projects/4/design.md
+++ b/docs/projects/4/design.md
@@ -1,0 +1,129 @@
+# #4 — Sub-Agent LLM for Tool-Side Work
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/4
+**Wave:** 1 (depends on: #14 secrets)
+
+## Current State
+
+Compaction uses the main model for summarization. No tools or infrastructure can independently call an LLM. Every LLM call burns main-model tokens.
+
+## Design
+
+### Interface
+
+New file `src/model/sub-agent.ts`:
+
+```typescript
+type SubAgentLLM = {
+  complete(prompt: string, system?: string): Promise<string>;
+};
+```
+
+Deliberately **not** `ModelProvider` — no tools, no content blocks, no streaming. Pure text in, text out. Single-shot utility calls only.
+
+### Config
+
+New section `[sub_model]` in `config.toml`:
+
+```toml
+[sub_model]
+provider = "anthropic"               # anthropic | openai-compat | openrouter | ollama | lemonade
+name = "claude-haiku-4-5-20251001"
+max_tokens = 8000
+base_url = "..."                     # optional
+api_key = "..."                      # optional, env: SUB_MODEL_API_KEY
+```
+
+Add `SubModelConfig` to `src/config/types.ts`:
+
+```typescript
+type SubModelConfig = {
+  readonly provider: 'anthropic' | 'openai-compat' | 'openrouter' | 'ollama' | 'lemonade';
+  readonly name: string;
+  readonly maxTokens: number;        // default 8000
+  readonly baseUrl?: string;
+  readonly apiKey?: string;
+};
+```
+
+Add `subModel?: SubModelConfig` to `AppConfig`.
+
+### Provider Support
+
+All five model providers supported:
+
+- **Anthropic** — Anthropic SDK, messages API, text-only response extraction
+- **OpenAI-compat** — fetch-based POST to `/chat/completions`, extract `choices[0].message.content`
+- **OpenRouter** — same as OpenAI-compat but default base URL `https://openrouter.ai/api/v1`
+- **Ollama** — fetch to Ollama's `/api/chat` endpoint
+- **Lemonade** — OpenAI-compat variant, same extraction logic
+
+Implementation: a factory function `createSubAgent(config: SubModelConfig): SubAgentLLM` that switches on provider. Each branch is a thin wrapper — no shared code with the main model providers needed (these are simple single-shot calls).
+
+### Fallback
+
+If `[sub_model]` is not configured, create a `SubAgentLLM` that wraps the main `ModelProvider`:
+
+```typescript
+function wrapMainModel(model: ModelProvider, modelName: string, maxTokens: number): SubAgentLLM {
+  return {
+    async complete(prompt, system) {
+      const response = await model.complete({
+        messages: [{ role: 'user', content: prompt }],
+        system,
+        tools: [],
+        model: modelName,
+        max_tokens: Math.min(maxTokens, 8000),
+      });
+      // extract text from content blocks
+      return response.content
+        .filter(b => b.type === 'text')
+        .map(b => b.text)
+        .join('');
+    },
+  };
+}
+```
+
+This means no feature is gated on having a separate sub-model — compaction, titles, and summarize all work regardless. They just use the expensive model as a fallback.
+
+### Wiring
+
+In `src/index.ts`:
+1. If `config.subModel` exists: `createSubAgent(config.subModel)`
+2. Otherwise: `wrapMainModel(model, config.model.name, config.model.maxTokens)`
+3. Pass into `AgentDependencies` as `subAgent: SubAgentLLM`
+
+Add `subAgent?: SubAgentLLM` to `AgentDependencies` in `src/agent/types.ts`.
+
+### Compaction Update
+
+In `src/agent/compaction.ts`, update `summarizeOlderContext()`:
+- Accept `subAgent: SubAgentLLM` instead of `model: ModelProvider` + `modelName` + `maxTokens`
+- Call `subAgent.complete(combined, systemPrompt)` instead of `model.complete({...})`
+- Simplifies the function signature and uses the cheaper model when available
+
+### Consumers
+
+- Compaction (`src/agent/compaction.ts`) — immediate
+- Session titles (#5) — uses `deps.subAgent`
+- Summarize tool (#8) — uses `deps.subAgent`
+
+## Files Touched
+
+- `src/config/types.ts` — add `SubModelConfig`, add to `AppConfig`
+- `src/config/loader.ts` — parse `[sub_model]` section, env overrides
+- `src/model/sub-agent.ts` — new file, factory + all five provider implementations
+- `src/agent/types.ts` — add `subAgent?: SubAgentLLM` to `AgentDependencies`
+- `src/agent/compaction.ts` — switch to sub-agent for summarization
+- `src/index.ts` — create and wire sub-agent
+
+## Acceptance Criteria
+
+1. `SubAgentLLM` type exported with `complete(prompt, system?) → Promise<string>`
+2. All five providers work: anthropic, openai-compat, openrouter, ollama, lemonade
+3. Fallback wraps main model when `[sub_model]` not configured
+4. Compaction uses sub-agent instead of main model
+5. `subAgent` available on `AgentDependencies` for downstream consumers
+6. Config: `SUB_MODEL_API_KEY` env var overrides TOML
+7. Test: mock sub-agent returns expected text for each provider variant

--- a/docs/projects/4/implementation-plan/phase_01.md
+++ b/docs/projects/4/implementation-plan/phase_01.md
@@ -1,0 +1,136 @@
+# Sub-Agent LLM Implementation Plan -- Phase 1: Config Types and TOML Loader
+
+**Goal:** Add `SubModelConfig` type and `[sub_model]` TOML parsing so the sub-agent can be configured independently of the main model.
+
+**Architecture:** Extends the existing config layer (`src/config/types.ts` + `src/config/loader.ts`) with a new optional `subModel` field on `AppConfig`. The loader parses a `[sub_model]` TOML section using the same `pick()` helper pattern as the main `[model]` section. Environment variable overrides follow the existing `resolveApiKey`/`resolveBaseUrl` pattern with `SUB_MODEL_` prefixed env vars.
+
+**Tech Stack:** TypeScript, TOML (via `toml` package), Bun runtime
+
+**Scope:** 4 phases from original design (phase 1 of 4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH04.AC1: SubAgentLLM type exported with `complete(prompt, system?) -> Promise<string>`
+- **GH04.AC1.1 Success:** `SubModelConfig` type defined and added to `AppConfig` (type only -- implementation in Phase 2)
+
+### GH04.AC6: Config: `SUB_MODEL_API_KEY` env var overrides TOML
+- **GH04.AC6.1 Success:** `[sub_model]` TOML section parsed with env var overrides for `SUB_MODEL_API_KEY`, `SUB_MODEL_BASE_URL`, `SUB_MODEL_NAME`
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Add `SubModelConfig` type to `src/config/types.ts`
+
+**Verifies:** GH04.AC1.1
+
+**Files:**
+- Modify: `src/config/types.ts` (add type after `ModelConfig`, add field to `AppConfig`)
+
+**Implementation:**
+
+Add the `SubModelConfig` type after the existing `ModelConfig` type (after line 12). It reuses the same provider union as `ModelConfig`:
+
+```typescript
+export type SubModelConfig = {
+  readonly provider: 'anthropic' | 'openai-compat' | 'openrouter' | 'ollama' | 'lemonade';
+  readonly name: string;
+  readonly maxTokens: number;
+  readonly baseUrl?: string;
+  readonly apiKey?: string;
+};
+```
+
+Add `subModel` as an optional field to `AppConfig`:
+
+```typescript
+export type AppConfig = {
+  readonly model: ModelConfig;
+  readonly runtime: RuntimeConfig;
+  readonly agent: AgentLoopConfig;
+  readonly embedding?: EmbeddingConfig;
+  readonly discord?: DiscordConfig;
+  readonly interface: InterfaceMode;
+  readonly subModel?: SubModelConfig;
+};
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `feat(config): add SubModelConfig type to AppConfig`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Parse `[sub_model]` TOML section in `src/config/loader.ts`
+
+**Verifies:** GH04.AC6.1
+
+**Files:**
+- Modify: `src/config/loader.ts` (update `RawConfig` type, add parsing block, update import, update return)
+
+**Implementation:**
+
+1. Update the `RawConfig` type to include `sub_model`:
+
+```typescript
+type RawConfig = {
+  model?: Partial<ModelConfig> & Record<string, unknown>;
+  runtime?: Partial<RuntimeConfig> & Record<string, unknown>;
+  agent?: Partial<AgentLoopConfig> & Record<string, unknown>;
+  embedding?: Partial<EmbeddingConfig> & Record<string, unknown>;
+  discord?: Partial<DiscordConfig> & Record<string, unknown>;
+  sub_model?: Partial<SubModelConfig> & Record<string, unknown>;
+  interface?: string;
+};
+```
+
+2. Add `SubModelConfig` to the import from `./types.ts`.
+
+3. Add a parsing block after the `discord` section (before the `rawInterface` line) that checks whether `raw.sub_model` exists OR env vars are set. If a sub-model provider is detected, build the `SubModelConfig`. The env var resolution follows the existing pattern:
+
+```typescript
+// Sub-model config (optional -- for cheaper LLM calls in compaction, titles, etc.)
+const subModelProvider = process.env['SUB_MODEL_PROVIDER']
+  ?? pick(raw.sub_model, 'provider', undefined);
+
+const subModel: SubModelConfig | undefined = subModelProvider
+  ? {
+      provider: subModelProvider as SubModelConfig['provider'],
+      name: process.env['SUB_MODEL_NAME']
+        ?? pick(raw.sub_model, 'name', 'claude-haiku-4-5-20251001'),
+      maxTokens: pick(raw.sub_model, 'maxTokens', 8000),
+      apiKey: process.env['SUB_MODEL_API_KEY']
+        ?? resolveApiKey(subModelProvider, pick(raw.sub_model, 'apiKey', undefined)),
+      baseUrl: process.env['SUB_MODEL_BASE_URL']
+        ?? resolveBaseUrl(subModelProvider, pick(raw.sub_model, 'baseUrl', undefined)),
+    }
+  : undefined;
+```
+
+Note: `resolveApiKey` and `resolveBaseUrl` already handle provider-specific defaults (e.g., Anthropic falls back to `ANTHROPIC_API_KEY`, OpenRouter defaults base URL to `https://openrouter.ai/api/v1`). The sub-model reuses these, with `SUB_MODEL_API_KEY` and `SUB_MODEL_BASE_URL` taking priority when set.
+
+4. Update the return statement to include `subModel`:
+
+```typescript
+return { model, runtime, agent, embedding, discord, interface: interfaceMode, subModel };
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `feat(config): parse [sub_model] TOML section with env var overrides`
+
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/4/implementation-plan/phase_02.md
+++ b/docs/projects/4/implementation-plan/phase_02.md
@@ -1,0 +1,145 @@
+# Sub-Agent LLM Implementation Plan -- Phase 2: Sub-Agent Factory and Provider Implementations
+
+**Goal:** Create `src/model/sub-agent.ts` with the `SubAgentLLM` type, a factory function for all five providers, and a fallback wrapper for the main `ModelProvider`.
+
+**Architecture:** `SubAgentLLM` is deliberately minimal -- `complete(prompt, system?) -> Promise<string>`. It is NOT a `ModelProvider` (no tools, no content blocks, no streaming). The factory function `createSubAgent()` switches on provider and returns thin fetch-based wrappers for each. The `wrapMainModel()` fallback adapts the existing `ModelProvider.complete()` interface for use when no sub-model is configured. Each provider implementation is self-contained -- no shared code with the main model providers is needed since these are simple single-shot calls.
+
+**Tech Stack:** TypeScript, Anthropic SDK (`@anthropic-ai/sdk` v0.39.0), `fetch` for OpenAI-compat/OpenRouter/Ollama endpoints, Bun runtime
+
+**Scope:** 4 phases from original design (phase 2 of 4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH04.AC1: SubAgentLLM type exported with `complete(prompt, system?) -> Promise<string>`
+- **GH04.AC1.1 Success:** `SubAgentLLM` type defined and exported from `src/model/sub-agent.ts`
+- **GH04.AC1.2 Success:** `complete()` accepts prompt string and optional system string, returns `Promise<string>`
+
+### GH04.AC2: All five providers work: anthropic, openai-compat, openrouter, ollama, lemonade
+- **GH04.AC2.1 Success:** Anthropic provider uses Anthropic SDK messages API, extracts text-only response
+- **GH04.AC2.2 Success:** OpenAI-compat provider uses fetch POST to `/chat/completions`, extracts `choices[0].message.content`
+- **GH04.AC2.3 Success:** OpenRouter provider uses same fetch logic as OpenAI-compat but defaults base URL to `https://openrouter.ai/api/v1`
+- **GH04.AC2.4 Success:** Ollama provider uses fetch POST to `/api/chat`, extracts `message.content`
+- **GH04.AC2.5 Success:** Lemonade provider delegates to OpenAI-compat with default base URL `http://localhost:13305/api/v1` and API key `lemonade`
+
+### GH04.AC3: Fallback wraps main model when `[sub_model]` not configured
+- **GH04.AC3.1 Success:** `wrapMainModel()` accepts `ModelProvider` + model name + maxTokens, returns `SubAgentLLM`
+- **GH04.AC3.2 Success:** Fallback calls `model.complete()` with `tools: []` and extracts text from content blocks
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Create `src/model/sub-agent.ts` with type, factory, and all provider implementations
+
+**Verifies:** GH04.AC1.1, GH04.AC1.2, GH04.AC2.1, GH04.AC2.2, GH04.AC2.3, GH04.AC2.4, GH04.AC2.5
+
+**Files:**
+- Create: `src/model/sub-agent.ts`
+
+**Implementation:**
+
+Create the file with `// pattern: Imperative Shell` header. The file exports:
+
+1. **`SubAgentLLM` type:**
+```typescript
+export type SubAgentLLM = {
+  complete(prompt: string, system?: string): Promise<string>;
+};
+```
+
+2. **`createSubAgent(config: SubModelConfig): SubAgentLLM` factory** that switches on `config.provider`:
+
+**Anthropic branch:** Uses the Anthropic SDK (already a dependency at `@anthropic-ai/sdk` v0.39.0). Creates an `Anthropic` client with the config's `apiKey`. Calls `client.messages.create()` with:
+- `model`: config.name
+- `max_tokens`: config.maxTokens
+- `messages`: `[{ role: 'user', content: prompt }]`
+- `system`: the system param if provided
+Extracts text by filtering response content blocks for `type === 'text'` and joining their `.text` values.
+
+**OpenAI-compat branch:** Uses `fetch` POST to `config.baseUrl + '/chat/completions'`. Request body:
+- `model`: config.name
+- `max_tokens`: config.maxTokens
+- `messages`: system message (if provided) + user message
+Response parsing: `choices[0].message.content` (same pattern as `src/model/openai-compat.ts` lines 248-281 but drastically simplified -- no tool handling needed).
+Includes `Authorization: Bearer ${config.apiKey}` header when apiKey is set.
+Timeout: 120s via `AbortController`.
+
+**OpenRouter branch:** Identical to OpenAI-compat. The only difference is the default `baseUrl` which is already resolved by the config loader in Phase 1 (defaults to `https://openrouter.ai/api/v1` via `resolveBaseUrl`). Delegates to the same internal fetch logic. Can be implemented by extracting a shared helper function used by both openai-compat and openrouter branches.
+
+**Ollama branch:** Uses `fetch` POST to `config.baseUrl + '/api/chat'` (default Ollama base URL is `http://localhost:11434`, resolved by config loader). Request body:
+- `model`: config.name
+- `messages`: system message (if provided) + user message
+- `stream`: false
+- `options.num_predict`: config.maxTokens
+Response parsing: `response.message.content` (same structure as `src/model/ollama.ts` lines 163-168 but without tool handling).
+
+**Lemonade branch:** Delegates to the OpenAI-compat logic. The config loader already resolves the default base URL (`http://localhost:13305/api/v1`) and API key (`lemonade`) via `resolveBaseUrl` and `resolveApiKey`. No special handling needed -- just reuse the OpenAI-compat code path.
+
+Implementation pattern: extract a `completeViaOpenAI(baseUrl, apiKey, model, maxTokens, prompt, system?)` helper for the OpenAI-compat, OpenRouter, and Lemonade branches to share. Anthropic and Ollama each get their own inline implementation due to different API shapes.
+
+Error handling: wrap each provider's call in try/catch. On failure, throw with a descriptive message including the provider name and original error.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `feat(model): create sub-agent factory with all five provider implementations`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Add `wrapMainModel()` fallback function
+
+**Verifies:** GH04.AC3.1, GH04.AC3.2
+
+**Files:**
+- Modify: `src/model/sub-agent.ts` (add function after factory)
+
+**Implementation:**
+
+Add an exported function to `src/model/sub-agent.ts`:
+
+```typescript
+export function wrapMainModel(
+  model: ModelProvider,
+  modelName: string,
+  maxTokens: number,
+): SubAgentLLM {
+  return {
+    async complete(prompt: string, system?: string): Promise<string> {
+      const response = await model.complete({
+        messages: [{ role: 'user', content: prompt }],
+        system,
+        tools: [],
+        model: modelName,
+        max_tokens: Math.min(maxTokens, 8000),
+      });
+      return response.content
+        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+        .map((b) => b.text)
+        .join('');
+    },
+  };
+}
+```
+
+This requires importing `ModelProvider` from `./types.ts`. The `tools: []` is intentional -- sub-agent calls are pure text completion, no tool use.
+
+The `Math.min(maxTokens, 8000)` cap prevents the fallback from burning excessive tokens on what should be a cheap utility call (compaction summaries, session titles, etc.).
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `feat(model): add wrapMainModel fallback for sub-agent`
+
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/4/implementation-plan/phase_03.md
+++ b/docs/projects/4/implementation-plan/phase_03.md
@@ -1,0 +1,268 @@
+# Sub-Agent LLM Implementation Plan -- Phase 3: Wiring and Compaction Update
+
+**Goal:** Wire the sub-agent into `AgentDependencies`, create it in `src/index.ts`, and update compaction to use it instead of the main model.
+
+**Architecture:** The sub-agent is created once in `main()` (either via `createSubAgent` if configured, or `wrapMainModel` as fallback) and passed through `AgentDependencies` to all consumers. Compaction's `summarizeOlderContext()` is simplified from accepting `model + modelName + maxTokens` to accepting a single `SubAgentLLM`. The `compactContext` deps object is similarly simplified.
+
+**Tech Stack:** TypeScript, Bun runtime
+
+**Scope:** 4 phases from original design (phase 3 of 4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH04.AC4: Compaction uses sub-agent instead of main model
+- **GH04.AC4.1 Success:** `summarizeOlderContext()` calls `subAgent.complete()` instead of `model.complete()`
+- **GH04.AC4.2 Success:** `compactContext()` deps parameter uses `subAgent: SubAgentLLM` instead of `model: ModelProvider` + `modelName` + `maxTokens`
+
+### GH04.AC5: `subAgent` available on `AgentDependencies` for downstream consumers
+- **GH04.AC5.1 Success:** `subAgent` field added to `AgentDependencies` type (optional, since fallback is created in index.ts)
+- **GH04.AC5.2 Success:** Sub-agent created and passed into `AgentDependencies` in `src/index.ts`
+
+---
+
+<!-- START_TASK_1 -->
+### Task 1: Add `subAgent` to `AgentDependencies` in `src/agent/types.ts`
+
+**Verifies:** GH04.AC5.1
+
+**Files:**
+- Modify: `src/agent/types.ts` (add import, add field)
+
+**Implementation:**
+
+1. Add import for `SubAgentLLM` at the top of the file:
+
+```typescript
+import type { SubAgentLLM } from '../model/sub-agent.ts';
+```
+
+2. Add `subAgent` as an optional field to `AgentDependencies` (after the `secrets` field on line 45):
+
+```typescript
+export type AgentDependencies = {
+  readonly model: ModelProvider;
+  readonly runtime: CodeRuntime;
+  readonly config: AgentConfig;
+  readonly personaPath: string;
+  readonly embedding?: EmbeddingProvider;
+  readonly vectorStore?: VectorStore;
+  readonly scheduler?: TaskStore;
+  readonly store: Store;
+  readonly secrets?: SecretManager;
+  readonly subAgent?: SubAgentLLM;
+};
+```
+
+The field is optional so existing call sites (tests, etc.) don't break. The wiring in `src/index.ts` (Task 3) will always provide it.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `feat(agent): add subAgent field to AgentDependencies`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Update compaction to use sub-agent
+
+**Verifies:** GH04.AC4.1, GH04.AC4.2
+
+**Files:**
+- Modify: `src/agent/compaction.ts` (update import, update function signatures, update function bodies)
+
+**Implementation:**
+
+1. Replace the `ModelProvider` import with `SubAgentLLM`:
+
+Change the import on line 9 from:
+```typescript
+import type { Message, ModelProvider } from '../model/types.ts';
+```
+to:
+```typescript
+import type { Message } from '../model/types.ts';
+import type { SubAgentLLM } from '../model/sub-agent.ts';
+```
+
+2. Simplify `summarizeOlderContext()` (lines 90-119). Change the signature from:
+
+```typescript
+async function summarizeOlderContext(
+  model: ModelProvider,
+  modelName: string,
+  maxTokens: number,
+  notes: ReadonlyArray<string>,
+): Promise<string> {
+```
+
+to:
+
+```typescript
+async function summarizeOlderContext(
+  subAgent: SubAgentLLM,
+  notes: ReadonlyArray<string>,
+): Promise<string> {
+```
+
+Replace the body's `model.complete()` call (lines 103-118) with:
+
+```typescript
+  if (notes.length === 0) return '';
+
+  const combined = notes
+    .map((text, i) => `--- Context ${i + 1} ---\n${text.slice(0, 3000)}`)
+    .join('\n\n');
+
+  const system =
+    'You are a context summarizer. Given conversation logs, produce a concise 2-4 sentence summary capturing the key topics discussed, decisions made, and any important facts or preferences revealed. Focus on what would be useful for continuing the conversation. Do not use markdown headers or bullet points -- write flowing prose.';
+
+  const text = await subAgent.complete(combined, system);
+  return text || '(summary unavailable)';
+```
+
+This eliminates the response content block filtering -- `SubAgentLLM.complete()` already returns plain text.
+
+3. Update `compactContext()` deps parameter (lines 128-136). Change from:
+
+```typescript
+export async function compactContext(
+  messages: ReadonlyArray<Message>,
+  deps: {
+    store: Store;
+    model: ModelProvider;
+    modelName: string;
+    maxTokens: number;
+  },
+): Promise<Array<Message>> {
+```
+
+to:
+
+```typescript
+export async function compactContext(
+  messages: ReadonlyArray<Message>,
+  deps: {
+    store: Store;
+    subAgent: SubAgentLLM;
+  },
+): Promise<Array<Message>> {
+```
+
+4. Update the `summarizeOlderContext` call site inside `compactContext()` (lines 157-161). Change from:
+
+```typescript
+    olderSummary = await summarizeOlderContext(
+      deps.model,
+      deps.modelName,
+      deps.maxTokens,
+      olderDocs.map((d) => d.content),
+    );
+```
+
+to:
+
+```typescript
+    olderSummary = await summarizeOlderContext(
+      deps.subAgent,
+      olderDocs.map((d) => d.content),
+    );
+```
+
+5. Update the `compactContext` call site in `src/agent/agent.ts` (lines 135-140). Change from:
+
+```typescript
+      const compacted = await compactContext(history, {
+        store: deps.store,
+        model: deps.model,
+        modelName: deps.config.model,
+        maxTokens: deps.config.maxTokens,
+      });
+```
+
+to:
+
+```typescript
+      const compacted = await compactContext(history, {
+        store: deps.store,
+        subAgent: deps.subAgent!,
+      });
+```
+
+The `!` assertion is safe because `src/index.ts` (Task 3) always provides `subAgent` via either `createSubAgent` or `wrapMainModel`. The type is optional on `AgentDependencies` for API flexibility, but the wiring guarantees it at runtime.
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+**Commit:** `refactor(compaction): use SubAgentLLM instead of main ModelProvider`
+
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Wire sub-agent creation in `src/index.ts`
+
+**Verifies:** GH04.AC5.2
+
+**Files:**
+- Modify: `src/index.ts` (add imports, add creation logic, add to agentDeps)
+
+**Implementation:**
+
+1. Add imports after the existing model import (line 11):
+
+```typescript
+import { createSubAgent, wrapMainModel } from './model/sub-agent.ts';
+import type { SubAgentLLM } from './model/sub-agent.ts';
+```
+
+2. After the `secrets` creation (line 48) and before the `embedding` block (line 51), add sub-agent creation:
+
+```typescript
+  // Sub-agent LLM -- cheap model for compaction, titles, summarization
+  // Falls back to wrapping the main model if [sub_model] not configured
+  const subAgent: SubAgentLLM = config.subModel
+    ? createSubAgent(config.subModel)
+    : wrapMainModel(model, config.model.name, config.model.maxTokens);
+```
+
+3. Add `subAgent` to the `agentDeps` object (after `secrets` on line 93):
+
+```typescript
+  const agentDeps: AgentDependencies = {
+    model,
+    runtime,
+    config: {
+      model: config.model.name,
+      maxTokens: config.model.maxTokens,
+      maxToolRounds: config.agent.maxToolRounds,
+      contextBudget: config.agent.contextBudget,
+      contextLimit: config.agent.contextLimit,
+      modelTimeout: config.agent.modelTimeout,
+      timezone: config.agent.timezone,
+    },
+    personaPath: PERSONA_PATH,
+    embedding,
+    get scheduler() { return scheduler; },
+    store,
+    secrets,
+    subAgent,
+  };
+```
+
+**Verification:**
+Run: `bunx tsc --noEmit`
+Expected: No type errors
+
+Run: `bun run build`
+Expected: Builds without errors
+
+**Commit:** `feat: wire sub-agent creation into main startup`
+
+<!-- END_TASK_3 -->

--- a/docs/projects/4/implementation-plan/phase_04.md
+++ b/docs/projects/4/implementation-plan/phase_04.md
@@ -1,0 +1,229 @@
+# Sub-Agent LLM Implementation Plan -- Phase 4: Tests
+
+**Goal:** Add tests verifying the sub-agent factory, all provider variants, the main model fallback, config parsing, and compaction integration.
+
+**Architecture:** Tests use Bun's built-in test runner (`bun test`). The project has no existing test files, so this phase establishes the test directory structure. Provider tests mock `fetch` (for openai-compat, openrouter, ollama, lemonade) and the Anthropic SDK client (for anthropic). The compaction test mocks the `SubAgentLLM` interface directly. Config tests exercise `loadConfig` with temp TOML files.
+
+**Tech Stack:** TypeScript, Bun test runner (`bun:test`), `mock` from `bun:test` for mocking
+
+**Scope:** 4 phases from original design (phase 4 of 4)
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase tests:
+
+### GH04.AC1: SubAgentLLM type exported with `complete(prompt, system?) -> Promise<string>`
+- **GH04.AC1.1 Success:** Type is importable and usable in test code
+
+### GH04.AC2: All five providers work: anthropic, openai-compat, openrouter, ollama, lemonade
+- **GH04.AC2.1 Success:** Anthropic provider extracts text from messages API response
+- **GH04.AC2.2 Success:** OpenAI-compat provider extracts `choices[0].message.content`
+- **GH04.AC2.3 Success:** OpenRouter provider defaults base URL and extracts response
+- **GH04.AC2.4 Success:** Ollama provider extracts `message.content` from `/api/chat`
+- **GH04.AC2.5 Success:** Lemonade provider delegates to OpenAI-compat logic
+
+### GH04.AC3: Fallback wraps main model when `[sub_model]` not configured
+- **GH04.AC3.1 Success:** `wrapMainModel` calls `model.complete()` with `tools: []` and returns text
+- **GH04.AC3.2 Success:** Fallback caps `max_tokens` at 8000
+
+### GH04.AC4: Compaction uses sub-agent instead of main model
+- **GH04.AC4.1 Success:** `compactContext` calls `subAgent.complete()` for summarization
+
+### GH04.AC6: Config: `SUB_MODEL_API_KEY` env var overrides TOML
+- **GH04.AC6.1 Success:** Env var `SUB_MODEL_API_KEY` takes precedence over TOML `api_key`
+- **GH04.AC6.2 Success:** Missing `[sub_model]` section results in `undefined` on `AppConfig`
+
+### GH04.AC7: Test: mock sub-agent returns expected text for each provider variant
+- **GH04.AC7.1 Success:** Each provider test verifies the returned string matches the mock response text
+
+---
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Create sub-agent provider tests
+
+**Verifies:** GH04.AC1.1, GH04.AC2.1, GH04.AC2.2, GH04.AC2.3, GH04.AC2.4, GH04.AC2.5, GH04.AC7.1
+
+**Files:**
+- Create: `src/model/sub-agent.test.ts`
+
+**Implementation:**
+
+Uses `describe`/`test` from `bun:test` and `mock` for fetch mocking.
+
+Test cases to implement:
+
+1. **Anthropic provider:** Mock the Anthropic SDK's `messages.create` method to return a response with `content: [{ type: 'text', text: 'summary text' }]`. Call `createSubAgent({ provider: 'anthropic', name: 'claude-haiku-4-5-20251001', maxTokens: 8000, apiKey: 'test-key' })` and verify `complete('test prompt', 'test system')` returns `'summary text'`. The Anthropic SDK is instantiated inside `createSubAgent`, so mocking requires either: (a) using `mock.module` from `bun:test` to mock `@anthropic-ai/sdk`, or (b) refactoring the factory to accept an SDK constructor. Option (a) is simpler and matches Bun's test patterns.
+
+2. **OpenAI-compat provider:** Mock global `fetch` to return `{ choices: [{ message: { content: 'compat response' } }] }`. Call `createSubAgent({ provider: 'openai-compat', name: 'gpt-4o-mini', maxTokens: 4000, baseUrl: 'http://localhost:8080/v1', apiKey: 'test-key' })` and verify `complete('hello')` returns `'compat response'`. Also verify the fetch was called with the correct endpoint (`http://localhost:8080/v1/chat/completions`), method POST, and body containing `model`, `max_tokens`, and `messages`.
+
+3. **OpenRouter provider:** Mock global `fetch` same as OpenAI-compat. Call `createSubAgent({ provider: 'openrouter', name: 'meta-llama/llama-3-8b', maxTokens: 4000, baseUrl: 'https://openrouter.ai/api/v1', apiKey: 'or-key' })` and verify response text is extracted. Verify fetch URL is `https://openrouter.ai/api/v1/chat/completions`.
+
+4. **Ollama provider:** Mock global `fetch` to return `{ message: { content: 'ollama response' }, done_reason: 'stop' }`. Call `createSubAgent({ provider: 'ollama', name: 'llama3', maxTokens: 4000, baseUrl: 'http://localhost:11434' })` and verify `complete('test')` returns `'ollama response'`. Verify fetch URL is `http://localhost:11434/api/chat` and body includes `stream: false`.
+
+5. **Lemonade provider:** Mock global `fetch` same as OpenAI-compat. Call `createSubAgent({ provider: 'lemonade', name: 'local-model', maxTokens: 4000, baseUrl: 'http://localhost:13305/api/v1', apiKey: 'lemonade' })` and verify it uses the OpenAI-compat endpoint pattern. Verify fetch URL is `http://localhost:13305/api/v1/chat/completions`.
+
+6. **System prompt handling:** For each fetch-based provider, verify that when `system` is provided, the messages array includes a system message as the first element. When `system` is undefined, verify no system message is included.
+
+**Testing approach for fetch mocking:** Use Bun's `mock` to replace `globalThis.fetch` within each test, restoring it in `afterEach`. Structure:
+
+```typescript
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+```
+
+**Testing approach for Anthropic SDK mocking:** Use `mock.module` from `bun:test` to mock `@anthropic-ai/sdk`. The mock should return a constructor that provides a `messages.create` method:
+
+```typescript
+mock.module('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = {
+      create: mock(() => Promise.resolve({
+        content: [{ type: 'text', text: 'summary text' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      })),
+    };
+  },
+}));
+```
+
+**Verification:**
+Run: `bun test src/model/sub-agent.test.ts`
+Expected: All tests pass
+
+**Commit:** `test(model): add sub-agent provider tests`
+
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Create config loader tests for `[sub_model]` parsing
+
+**Verifies:** GH04.AC6.1, GH04.AC6.2
+
+**Files:**
+- Create: `src/config/loader.test.ts`
+
+**Implementation:**
+
+Test cases:
+
+1. **No `[sub_model]` section:** Write a minimal TOML config (just `[model]` with required fields) to a temp file. Call `loadConfig(tempPath)`. Verify `config.subModel` is `undefined`.
+
+2. **Full `[sub_model]` section:** Write TOML with:
+   ```toml
+   [sub_model]
+   provider = "anthropic"
+   name = "claude-haiku-4-5-20251001"
+   max_tokens = 4000
+   api_key = "toml-key"
+   ```
+   Call `loadConfig(tempPath)`. Verify `config.subModel` matches expected values.
+
+3. **Env var override:** Set `process.env['SUB_MODEL_API_KEY'] = 'env-key'` before calling `loadConfig`. Write TOML with `api_key = "toml-key"` in `[sub_model]`. Verify `config.subModel.apiKey === 'env-key'`. Clean up env var in afterEach.
+
+4. **Provider-specific defaults:** Write TOML with `provider = "openrouter"` in `[sub_model]` without `base_url`. Verify `config.subModel.baseUrl` is `'https://openrouter.ai/api/v1'` (from `resolveBaseUrl`).
+
+**Testing approach for temp files:** Use Bun's `Bun.write()` to create temp TOML files, and `fs.unlinkSync` for cleanup. Use `os.tmpdir()` for the temp directory:
+
+```typescript
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { unlinkSync } from 'node:fs';
+
+const tempPath = join(tmpdir(), `test-config-${Date.now()}.toml`);
+```
+
+Clean up env vars in `afterEach` to avoid test pollution:
+
+```typescript
+afterEach(() => {
+  delete process.env['SUB_MODEL_API_KEY'];
+  delete process.env['SUB_MODEL_PROVIDER'];
+  delete process.env['SUB_MODEL_NAME'];
+  delete process.env['SUB_MODEL_BASE_URL'];
+});
+```
+
+**Verification:**
+Run: `bun test src/config/loader.test.ts`
+Expected: All tests pass
+
+**Commit:** `test(config): add loader tests for [sub_model] parsing`
+
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Create `wrapMainModel` fallback and compaction integration tests
+
+**Verifies:** GH04.AC3.1, GH04.AC3.2, GH04.AC4.1
+
+**Files:**
+- Modify: `src/model/sub-agent.test.ts` (add describe block for wrapMainModel)
+- Create: `src/agent/compaction.test.ts`
+
+**Implementation:**
+
+**wrapMainModel tests** (add to `src/model/sub-agent.test.ts`):
+
+1. **Extracts text from content blocks:** Create a mock `ModelProvider` whose `complete()` returns `{ content: [{ type: 'text', text: 'hello' }, { type: 'text', text: ' world' }], stop_reason: 'end_turn', usage: { input_tokens: 10, output_tokens: 5 } }`. Call `wrapMainModel(mockModel, 'test-model', 16000)`. Verify `complete('prompt')` returns `'hello world'`.
+
+2. **Passes tools: [] to model:** Verify the mock's `complete` was called with `tools: []`.
+
+3. **Caps maxTokens at 8000:** Call `wrapMainModel(mockModel, 'test-model', 16384)`. Verify the mock's `complete` was called with `max_tokens: 8000`.
+
+4. **Passes system prompt through:** Call `complete('prompt', 'be helpful')`. Verify mock's `complete` was called with `system: 'be helpful'`.
+
+**Compaction integration test** (`src/agent/compaction.test.ts`):
+
+1. **`compactContext` uses sub-agent for summarization:** Create a mock `SubAgentLLM` that returns `'Earlier topics: weather, coding'`. Create a mock `Store` with enough context documents to trigger summarization (more than `RECENT_NOTES_COUNT = 3`):
+   - Mock `store.docUpsert` to no-op
+   - Mock `store.docList` to return 5 context documents with `rkey` starting with `context/`
+   Verify that after calling `compactContext(messages, { store, subAgent })`:
+   - The sub-agent's `complete` was called
+   - The returned messages contain the summary text
+   - The system prompt passed to `complete` contains 'context summarizer'
+
+2. **`compactContext` with few context docs skips summarization:** Set up only 2 context documents (fewer than `RECENT_NOTES_COUNT`). Verify sub-agent's `complete` was NOT called (no older docs to summarize).
+
+**Mock Store pattern:** The `Store` type is defined in `src/store/store.ts`. For tests, create a partial mock implementing only `docUpsert` and `docList`:
+
+```typescript
+const mockStore = {
+  docUpsert: mock(() => {}),
+  docList: mock(() => ({
+    documents: [
+      { rkey: 'context/2025-01-01T00-00-00', content: 'conversation 1' },
+      { rkey: 'context/2025-01-02T00-00-00', content: 'conversation 2' },
+      { rkey: 'context/2025-01-03T00-00-00', content: 'conversation 3' },
+      { rkey: 'context/2025-01-04T00-00-00', content: 'conversation 4' },
+      { rkey: 'context/2025-01-05T00-00-00', content: 'conversation 5' },
+    ],
+    total: 5,
+  })),
+} as unknown as Store;
+```
+
+**Verification:**
+Run: `bun test`
+Expected: All tests pass across all test files
+
+**Commit:** `test: add wrapMainModel and compaction integration tests`
+
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/4/implementation-plan/test-requirements.md
+++ b/docs/projects/4/implementation-plan/test-requirements.md
@@ -1,0 +1,41 @@
+# Sub-Agent LLM -- Test Requirements
+
+Derived from the Acceptance Criteria in `docs/projects/4/design.md`.
+
+## Automated Tests
+
+| AC | Criterion | Test Type | Test File | Description |
+|----|-----------|-----------|-----------|-------------|
+| GH04.AC1.1 | `SubAgentLLM` type exported | Unit | `src/model/sub-agent.test.ts` | Type is importable and used to create sub-agent instances |
+| GH04.AC2.1 | Anthropic provider works | Unit | `src/model/sub-agent.test.ts` | Mock Anthropic SDK, verify text extraction from messages API response |
+| GH04.AC2.2 | OpenAI-compat provider works | Unit | `src/model/sub-agent.test.ts` | Mock fetch, verify text extraction from `choices[0].message.content` |
+| GH04.AC2.3 | OpenRouter provider works | Unit | `src/model/sub-agent.test.ts` | Mock fetch, verify correct base URL and text extraction |
+| GH04.AC2.4 | Ollama provider works | Unit | `src/model/sub-agent.test.ts` | Mock fetch, verify `/api/chat` endpoint and `message.content` extraction |
+| GH04.AC2.5 | Lemonade provider works | Unit | `src/model/sub-agent.test.ts` | Mock fetch, verify delegates to OpenAI-compat pattern |
+| GH04.AC3.1 | Fallback wraps main model | Unit | `src/model/sub-agent.test.ts` | Mock ModelProvider, verify `tools: []` and text extraction |
+| GH04.AC3.2 | Fallback caps max_tokens | Unit | `src/model/sub-agent.test.ts` | Verify `max_tokens` capped at 8000 regardless of input |
+| GH04.AC4.1 | Compaction uses sub-agent | Unit | `src/agent/compaction.test.ts` | Mock SubAgentLLM, verify `complete()` called during compaction |
+| GH04.AC6.1 | Env var overrides TOML | Unit | `src/config/loader.test.ts` | Set `SUB_MODEL_API_KEY` env var, verify it overrides TOML value |
+| GH04.AC6.2 | Missing config returns undefined | Unit | `src/config/loader.test.ts` | Load config without `[sub_model]`, verify `subModel` is `undefined` |
+| GH04.AC7.1 | Mock returns expected text | Unit | `src/model/sub-agent.test.ts` | Each provider test verifies returned string matches mock |
+
+## Human Verification
+
+| AC | Criterion | Verification Approach |
+|----|-----------|----------------------|
+| GH04.AC5.1 | `subAgent` on AgentDependencies | Code review: verify field exists on type. TypeScript compiler enforces usage. |
+| GH04.AC5.2 | Sub-agent wired in index.ts | Code review: verify `createSubAgent`/`wrapMainModel` called and result passed to `agentDeps`. Manual smoke test: start agent, trigger compaction, verify logs show sub-agent activity. |
+
+**Justification for human verification:** GH04.AC5 concerns wiring in `src/index.ts` which requires a running config file, database, and model API keys to exercise end-to-end. The type system enforces correctness at compile time; manual smoke testing confirms runtime behavior.
+
+## Test Runner
+
+All tests use `bun test` (Bun's built-in test runner). No additional test framework is needed.
+
+## Test Files Summary
+
+| File | Tests | Covers |
+|------|-------|--------|
+| `src/model/sub-agent.test.ts` | ~12 | AC1, AC2, AC3, AC7 |
+| `src/config/loader.test.ts` | ~4 | AC6 |
+| `src/agent/compaction.test.ts` | ~2 | AC4 |

--- a/docs/projects/8/design.md
+++ b/docs/projects/8/design.md
@@ -1,0 +1,86 @@
+# #8 — Summarization Tool (via Sub-Agent)
+
+**Issue:** https://github.com/Numina-Systems/johnson/issues/8
+**Wave:** 2 (depends on: #3 registry mode, #4 sub-agent LLM)
+
+## Design
+
+### Why native-only
+
+The summarize tool calls the sub-agent LLM, which lives in the parent process. The Deno sandbox can't invoke it through IPC — the tool registry dispatches to handler functions, but the sub-agent is an async LLM call that returns text. The IPC protocol supports it (tool calls return results), so actually this *could* work through sandbox dispatch.
+
+Wait — re-examining: the sandbox calls `tools.summarize(...)` → IPC → parent process handler → `deps.subAgent.complete()` → returns text. That does work through the existing IPC protocol. The handler is just a function that happens to call an LLM internally.
+
+**Revised: `mode: 'both'`.** Available as native tool_use (simple direct calls) and via sandbox stubs (composable in execute_code — e.g., fetch page then summarize in one call).
+
+### Tool: `summarize`
+
+### Parameters
+
+- `text` (string, required) — content to summarize, truncated at 100k chars
+- `instructions` (string, optional) — focus guidance (e.g., "focus on technical claims")
+- `max_length` (string, optional) — `"short"` | `"medium"` | `"long"`, default `"medium"`
+
+### Length Guidance
+
+- `short` → "Respond in 2-3 sentences."
+- `medium` → "Respond in 1-2 paragraphs."
+- `long` → "Respond in up to 4 paragraphs."
+
+### Implementation
+
+```typescript
+async function summarize(params, deps): Promise<{ summary: string }> {
+  if (!deps.subAgent) {
+    throw new Error('Sub-agent LLM not configured. Add [sub_model] to config.toml.');
+  }
+
+  const text = str(params, 'text').slice(0, 100_000);
+  const instructions = optStr(params, 'instructions');
+  const maxLength = optStr(params, 'max_length', 'medium');
+
+  const lengthGuide: Record<string, string> = {
+    short: 'Respond in 2-3 sentences.',
+    medium: 'Respond in 1-2 paragraphs.',
+    long: 'Respond in up to 4 paragraphs.',
+  };
+
+  let prompt = `Summarize the following text. ${lengthGuide[maxLength] ?? lengthGuide.medium}`;
+  if (instructions) {
+    prompt += `\n\nFocus: ${instructions}`;
+  }
+  prompt += `\n\n---\n\n${text}`;
+
+  const system = 'You are a precise summarization assistant. Preserve key facts, names, and numbers. Do not add information not present in the source text.';
+
+  const result = await deps.subAgent.complete(prompt, system);
+  return { summary: result };
+}
+```
+
+### Registration
+
+New file `src/tools/summarize.ts` exporting:
+
+```typescript
+function registerSummarizeTools(registry: ToolRegistry, deps: AgentDependencies): void
+```
+
+Called from `createAgentTools()` in `src/agent/tools.ts`. Mode: `'both'`.
+
+## Files Touched
+
+- `src/tools/summarize.ts` — new file, tool definition + handler
+- `src/agent/tools.ts` �� call `registerSummarizeTools(registry, deps)`
+
+## Acceptance Criteria
+
+1. `summarize` sends text to sub-agent with appropriate system prompt
+2. Input truncated at 100k chars
+3. `max_length` maps to correct length guidance
+4. Optional `instructions` appended to prompt as focus guidance
+5. Missing sub-agent → clear error message
+6. Registered as `mode: 'both'` — native tool_use + sandbox stubs
+7. Test: mock sub-agent, verify prompt construction includes length guidance
+8. Test: mock sub-agent, verify instructions appended when provided
+9. Test: no sub-agent configured → verify error thrown

--- a/docs/projects/8/implementation-plan/phase_01.md
+++ b/docs/projects/8/implementation-plan/phase_01.md
@@ -1,0 +1,238 @@
+# GH08: Summarization Tool — Implementation Plan
+
+**Goal:** Add a `summarize` tool that sends text to a sub-agent LLM and returns a concise summary, with configurable length and optional focus instructions.
+
+**Architecture:** New file `src/tools/summarize.ts` exports a registration function that adds the `summarize` tool to the ToolRegistry. The tool handler calls `deps.subAgent.complete()` with a constructed prompt. Shared parameter helpers are extracted from `src/agent/tools.ts` into `src/tools/helpers.ts` so all tool files can reuse them. Registration is wired from `createAgentTools()` in `src/agent/tools.ts`.
+
+**Tech Stack:** TypeScript (Bun runtime), bun:test for testing
+
+**Scope:** 2 phases from design
+
+**Prerequisites:** This feature depends on two prior features that MUST be implemented before execution begins:
+- **#3 Multi-Tool Architecture** — `ToolRegistry.register()` must accept a `mode` parameter (`'sandbox' | 'native' | 'both'`), and `generateToolDefinitions()` must exist on the registry. The agent loop must dispatch native tool calls directly through the registry.
+- **#4 Sub-Agent LLM** — `SubAgentLLM` type must exist at `src/model/sub-agent.ts` with `complete(prompt: string, system?: string): Promise<string>`. `AgentDependencies` must include `subAgent?: SubAgentLLM`.
+
+**Verify prerequisites at execution time:** Before starting Phase 1, confirm:
+1. `src/model/sub-agent.ts` exists and exports `SubAgentLLM`
+2. `src/agent/types.ts` has `subAgent?: SubAgentLLM` on `AgentDependencies`
+3. `src/runtime/tool-registry.ts` `register()` accepts a `mode` parameter
+4. `src/runtime/tool-registry.ts` exports `generateToolDefinitions()` on the registry
+
+If any are missing, STOP and report — the dependency features have not been merged yet.
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase implements:
+
+### GH08.AC1: Sub-agent invocation
+- **GH08.AC1.1:** `summarize` sends text to sub-agent with appropriate system prompt
+
+### GH08.AC2: Input truncation
+- **GH08.AC2.1:** Input truncated at 100k chars
+
+### GH08.AC3: Length guidance mapping
+- **GH08.AC3.1:** `max_length` maps to correct length guidance
+
+### GH08.AC4: Optional instructions
+- **GH08.AC4.1:** Optional `instructions` appended to prompt as focus guidance
+
+### GH08.AC5: Missing sub-agent error
+- **GH08.AC5.1:** Missing sub-agent produces clear error message
+
+### GH08.AC6: Registration mode
+- **GH08.AC6.1:** Registered as `mode: 'both'` — native tool_use + sandbox stubs
+
+---
+
+## Phase 1: Tool Implementation and Registration
+
+<!-- START_SUBCOMPONENT_A (tasks 1-3) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Extract shared parameter helpers to `src/tools/helpers.ts`
+
+**Verifies:** None (infrastructure refactor enabling future tool files)
+
+**Files:**
+- Create: `src/tools/helpers.ts`
+- Modify: `src/agent/tools.ts` (lines 11-20, import section at line 5)
+
+**Implementation:**
+
+Create `src/tools/helpers.ts` with the `str` and `optStr` helper functions currently defined in `src/agent/tools.ts` (lines 11-19). These are parameter extraction utilities needed by every tool handler.
+
+```typescript
+// src/tools/helpers.ts
+// pattern: Functional Core — shared parameter extraction helpers for tool handlers
+
+/**
+ * Extract a required string parameter from tool input.
+ * Throws if the parameter is missing or not a string.
+ */
+export function str(input: Record<string, unknown>, key: string): string {
+  const val = input[key];
+  if (typeof val !== 'string') throw new Error(`missing required param: ${key}`);
+  return val;
+}
+
+/**
+ * Extract an optional string parameter from tool input.
+ * Returns the fallback value if the parameter is missing or not a string.
+ */
+export function optStr(input: Record<string, unknown>, key: string, fallback: string = ''): string {
+  const val = input[key];
+  return typeof val === 'string' ? val : fallback;
+}
+```
+
+Then update `src/agent/tools.ts`:
+- Remove the local `str` and `optStr` function definitions (lines 11-19)
+- Add import at the top: `import { str, optStr } from '../tools/helpers.ts';`
+- Keep `hashCode` in `src/agent/tools.ts` since it's only used there
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds with no errors. Existing tool registrations still use `str` and `optStr` unchanged.
+
+**Commit:** `refactor: extract shared tool parameter helpers to src/tools/helpers.ts`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Create `src/tools/summarize.ts` with tool definition and handler
+
+**Verifies:** GH08.AC1.1, GH08.AC2.1, GH08.AC3.1, GH08.AC4.1, GH08.AC5.1, GH08.AC6.1
+
+**Files:**
+- Create: `src/tools/summarize.ts`
+
+**Implementation:**
+
+Create the summarize tool module. The function accepts a `ToolRegistry` and `AgentDependencies`, and registers the `summarize` tool with `mode: 'both'`.
+
+The handler:
+1. Guards on `deps.subAgent` being defined — throws a clear error if not configured (AC5.1)
+2. Extracts `text` (required), truncates to 100,000 characters (AC2.1)
+3. Extracts optional `instructions` and `max_length` (default `'medium'`)
+4. Maps `max_length` to a length guidance string (AC3.1):
+   - `'short'` -> `'Respond in 2-3 sentences.'`
+   - `'medium'` -> `'Respond in 1-2 paragraphs.'`
+   - `'long'` -> `'Respond in up to 4 paragraphs.'`
+5. Builds the prompt: summarization instruction + length guidance + optional focus instructions (AC4.1) + the text to summarize
+6. Calls `deps.subAgent.complete(prompt, system)` with a system prompt that instructs precise, fact-preserving summarization (AC1.1)
+7. Returns `{ summary: result }`
+
+```typescript
+// src/tools/summarize.ts
+// pattern: Functional Core — summarize tool registration
+
+import type { ToolRegistry } from '../runtime/tool-registry.ts';
+import type { AgentDependencies } from '../agent/types.ts';
+import { str, optStr } from './helpers.ts';
+
+const LENGTH_GUIDANCE: Record<string, string> = {
+  short: 'Respond in 2-3 sentences.',
+  medium: 'Respond in 1-2 paragraphs.',
+  long: 'Respond in up to 4 paragraphs.',
+};
+
+const SUMMARIZE_SYSTEM = 'You are a precise summarization assistant. Preserve key facts, names, and numbers. Do not add information not present in the source text.';
+
+const MAX_INPUT_CHARS = 100_000;
+
+export function registerSummarizeTools(registry: ToolRegistry, deps: Readonly<AgentDependencies>): void {
+  registry.register(
+    'summarize',
+    {
+      name: 'summarize',
+      description:
+        `Summarize text using a sub-agent LLM. Returns a concise summary preserving key facts.
+
+Use for long documents, articles, or any content that needs condensing. Optionally provide focus instructions to guide what the summary emphasizes.`,
+      input_schema: {
+        type: 'object',
+        properties: {
+          text: { type: 'string', description: 'Content to summarize (truncated at 100k chars)' },
+          instructions: { type: 'string', description: 'Optional focus guidance (e.g., "focus on technical claims")' },
+          max_length: {
+            type: 'string',
+            enum: ['short', 'medium', 'long'],
+            description: 'Summary length: "short" (2-3 sentences), "medium" (1-2 paragraphs), "long" (up to 4 paragraphs). Default: "medium".',
+          },
+        },
+        required: ['text'],
+      },
+    },
+    async (params) => {
+      if (!deps.subAgent) {
+        throw new Error('Sub-agent LLM not configured. Add [sub_model] to config.toml.');
+      }
+
+      const text = str(params, 'text').slice(0, MAX_INPUT_CHARS);
+      const instructions = optStr(params, 'instructions');
+      const maxLength = optStr(params, 'max_length', 'medium');
+
+      let prompt = `Summarize the following text. ${LENGTH_GUIDANCE[maxLength] ?? LENGTH_GUIDANCE.medium}`;
+      if (instructions) {
+        prompt += `\n\nFocus: ${instructions}`;
+      }
+      prompt += `\n\n---\n\n${text}`;
+
+      const result = await deps.subAgent.complete(prompt, SUMMARIZE_SYSTEM);
+      return { summary: result };
+    },
+    'both',
+  );
+}
+```
+
+**Note on `register()` call:** The fourth argument `'both'` is the `mode` parameter added by #3 Multi-Tool Architecture. If at execution time `register()` does not accept a fourth argument, check the #3 implementation — the mode parameter may be passed differently (e.g., as part of the definition object). Adapt accordingly.
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds. The file compiles without type errors.
+
+**Commit:** `feat: add summarize tool (GH08)`
+<!-- END_TASK_2 -->
+
+<!-- START_TASK_3 -->
+### Task 3: Wire registration into `createAgentTools()`
+
+**Verifies:** GH08.AC6.1
+
+**Files:**
+- Modify: `src/agent/tools.ts` (add import at top, add registration call before `return registry`)
+
+**Implementation:**
+
+Add the import at the top of `src/agent/tools.ts`, alongside the existing imports:
+
+```typescript
+import { registerSummarizeTools } from '../tools/summarize.ts';
+```
+
+Add the registration call just before the `return registry;` line (currently line 327):
+
+```typescript
+  // ── summarize (via sub-agent) ──────────────────────────────────────────
+  registerSummarizeTools(registry, deps);
+
+  return registry;
+```
+
+This follows the existing pattern where `createAgentTools()` is the single wiring point for all tools.
+
+**Verification:**
+
+Run: `bun run build`
+Expected: Build succeeds. The summarize tool is now registered when the agent initializes.
+
+**Commit:** `feat: wire summarize tool registration (GH08)`
+<!-- END_TASK_3 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/8/implementation-plan/phase_02.md
+++ b/docs/projects/8/implementation-plan/phase_02.md
@@ -1,0 +1,153 @@
+# GH08: Summarization Tool — Phase 2: Tests
+
+**Goal:** Verify the summarize tool's behavior through automated tests covering all acceptance criteria.
+
+**Architecture:** Tests use `bun:test` with a mock `SubAgentLLM` to verify prompt construction, parameter handling, truncation, and error cases. No real LLM calls.
+
+**Tech Stack:** bun:test
+
+**Codebase verified:** 2026-04-27
+
+---
+
+## Acceptance Criteria Coverage
+
+This phase tests:
+
+### GH08.AC1: Sub-agent invocation
+- **GH08.AC1.1:** `summarize` sends text to sub-agent with appropriate system prompt
+
+### GH08.AC2: Input truncation
+- **GH08.AC2.1:** Input truncated at 100k chars
+
+### GH08.AC3: Length guidance mapping
+- **GH08.AC3.1:** `max_length` maps to correct length guidance
+
+### GH08.AC4: Optional instructions
+- **GH08.AC4.1:** Optional `instructions` appended to prompt as focus guidance
+
+### GH08.AC5: Missing sub-agent error
+- **GH08.AC5.1:** Missing sub-agent produces clear error message
+
+---
+
+## Phase 2: Tests
+
+<!-- START_SUBCOMPONENT_A (tasks 1-2) -->
+
+<!-- START_TASK_1 -->
+### Task 1: Create test file for summarize tool
+
+**Verifies:** GH08.AC1.1, GH08.AC2.1, GH08.AC3.1, GH08.AC4.1, GH08.AC5.1
+
+**Files:**
+- Create: `src/tools/summarize.test.ts`
+
+**Implementation:**
+
+This project has no existing test files, so this will be the first. Bun's test runner discovers `*.test.ts` files automatically — no configuration needed.
+
+The test strategy: create a mock `SubAgentLLM` that captures the `prompt` and `system` arguments passed to `complete()`, then assert against the captured values. This tests the tool's prompt construction behavior without calling a real LLM.
+
+You'll also need a minimal mock `ToolRegistry` since `registerSummarizeTools` calls `registry.register()`. The simplest approach: use the real `createToolRegistry()` from `src/runtime/tool-registry.ts` and call `registry.execute('summarize', params)` to invoke the handler.
+
+For `AgentDependencies`, only `subAgent` matters for this tool. Create a partial mock that satisfies the type with just `subAgent` set. Cast as needed to avoid mocking the entire dependency tree.
+
+**Test cases to write:**
+
+1. **AC1.1 — sends text to sub-agent with system prompt:**
+   - Call `summarize` with `{ text: 'Some content to summarize' }`
+   - Assert the mock's captured `system` argument equals the expected summarization system prompt (`'You are a precise summarization assistant...'`)
+   - Assert the mock's captured `prompt` argument contains the input text
+   - Assert the result contains `{ summary: <mock return value> }`
+
+2. **AC2.1 — input truncated at 100k chars:**
+   - Call `summarize` with `{ text: 'x'.repeat(200_000) }` (200k chars)
+   - Assert the mock's captured `prompt` contains at most ~100,000 chars of the input text (the prompt has some overhead from the instruction prefix, but the text portion should be 100k)
+   - A practical check: assert `prompt.length < 100_200` (allowing for the instruction prefix)
+
+3. **AC3.1 — max_length maps to correct guidance:**
+   - Call `summarize` with `{ text: 'test', max_length: 'short' }` -> assert prompt contains `'Respond in 2-3 sentences.'`
+   - Call `summarize` with `{ text: 'test', max_length: 'medium' }` -> assert prompt contains `'Respond in 1-2 paragraphs.'`
+   - Call `summarize` with `{ text: 'test', max_length: 'long' }` -> assert prompt contains `'Respond in up to 4 paragraphs.'`
+   - Call `summarize` with `{ text: 'test' }` (no max_length) -> assert prompt contains `'Respond in 1-2 paragraphs.'` (default medium)
+
+4. **AC4.1 — instructions appended as focus guidance:**
+   - Call `summarize` with `{ text: 'test', instructions: 'focus on technical claims' }`
+   - Assert the mock's captured `prompt` contains `'Focus: focus on technical claims'`
+
+5. **AC4.1 (negative) — no instructions, no focus line:**
+   - Call `summarize` with `{ text: 'test' }` (no instructions)
+   - Assert the mock's captured `prompt` does NOT contain `'Focus:'`
+
+6. **AC5.1 — missing sub-agent throws clear error:**
+   - Register the tool with `deps.subAgent` set to `undefined`
+   - Call `summarize` with `{ text: 'test' }`
+   - Assert the call throws/rejects with an error message containing `'Sub-agent LLM not configured'`
+
+**Test skeleton:**
+
+```typescript
+// src/tools/summarize.test.ts
+import { describe, test, expect } from 'bun:test';
+import { createToolRegistry } from '../runtime/tool-registry.ts';
+import { registerSummarizeTools } from './summarize.ts';
+import type { AgentDependencies } from '../agent/types.ts';
+
+function makeMockSubAgent() {
+  let capturedPrompt = '';
+  let capturedSystem = '';
+  return {
+    captured: { get prompt() { return capturedPrompt; }, get system() { return capturedSystem; } },
+    subAgent: {
+      async complete(prompt: string, system?: string): Promise<string> {
+        capturedPrompt = prompt;
+        capturedSystem = system ?? '';
+        return 'Mock summary result.';
+      },
+    },
+  };
+}
+
+function setupRegistry(subAgent?: { complete(prompt: string, system?: string): Promise<string> }) {
+  const registry = createToolRegistry();
+  const deps = { subAgent } as unknown as AgentDependencies;
+  registerSummarizeTools(registry, deps);
+  return registry;
+}
+
+describe('summarize tool', () => {
+  // Test cases 1-6 as described above
+});
+```
+
+**Testing:**
+
+Run: `bun test`
+Expected: All 6+ test cases pass.
+
+**Verification:**
+
+Run: `bun test`
+Expected: `6 pass` (or however many individual test cases you wrote). Zero failures.
+
+**Commit:** `test: add summarize tool tests (GH08)`
+<!-- END_TASK_1 -->
+
+<!-- START_TASK_2 -->
+### Task 2: Verify end-to-end build
+
+**Verifies:** None (final verification)
+
+**Files:** None (read-only verification)
+
+**Steps:**
+
+1. Run `bun run build` — expected: succeeds
+2. Run `bun test` — expected: all tests pass
+3. Verify no TypeScript errors: `bunx tsc --noEmit` — expected: clean
+
+**Commit:** No commit needed. This is a verification step.
+<!-- END_TASK_2 -->
+
+<!-- END_SUBCOMPONENT_A -->

--- a/docs/projects/8/implementation-plan/test-requirements.md
+++ b/docs/projects/8/implementation-plan/test-requirements.md
@@ -1,0 +1,29 @@
+# GH08: Summarization Tool — Test Requirements
+
+## Acceptance Criteria to Test Mapping
+
+| AC ID | Criterion | Test Type | Test File | Automated? |
+|-------|-----------|-----------|-----------|------------|
+| GH08.AC1.1 | `summarize` sends text to sub-agent with appropriate system prompt | Unit | `src/tools/summarize.test.ts` | Yes |
+| GH08.AC2.1 | Input truncated at 100k chars | Unit | `src/tools/summarize.test.ts` | Yes |
+| GH08.AC3.1 | `max_length` maps to correct length guidance | Unit | `src/tools/summarize.test.ts` | Yes |
+| GH08.AC4.1 | Optional `instructions` appended to prompt as focus guidance | Unit | `src/tools/summarize.test.ts` | Yes |
+| GH08.AC5.1 | Missing sub-agent produces clear error message | Unit | `src/tools/summarize.test.ts` | Yes |
+| GH08.AC6.1 | Registered as `mode: 'both'` — native tool_use + sandbox stubs | Unit | `src/tools/summarize.test.ts` | Yes (verify via registry inspection after registration) |
+
+## Human Verification
+
+| AC ID | Criterion | Justification | Verification Approach |
+|-------|-----------|---------------|----------------------|
+| GH08.AC6.1 (partial) | Tool actually appears in both native tool_use list AND sandbox stubs at runtime | Full end-to-end with a real model requires a running agent | Start agent with `bun start`, send a message asking to summarize something, verify it works both as native tool call and in execute_code |
+
+## Test Design Notes
+
+- All automated tests use a mock `SubAgentLLM` that captures `prompt` and `system` arguments
+- No real LLM calls are made in tests
+- The mock returns a fixed string; tests assert on prompt construction, not on LLM output quality
+- Truncation test uses a 200k character string and verifies the prompt stays under ~100.2k (100k text + instruction overhead)
+- Length guidance tests verify each of the three variants plus the default (no `max_length` specified)
+- Instructions test verifies both presence (when provided) and absence (when omitted) of the `Focus:` line
+- Error test verifies the thrown error message text, not just that an error is thrown
+- Registration mode test: after calling `registerSummarizeTools`, inspect the registry to confirm the tool is registered. If #3 exposes a way to query tool mode or if `generateToolDefinitions()` includes it, use that to verify `mode: 'both'`. Otherwise, verify the tool appears in both `generateToolDefinitions()` output (native) and `generateTypeScriptStubs()` output (sandbox).

--- a/docs/projects/feature-parity-dag.md
+++ b/docs/projects/feature-parity-dag.md
@@ -1,0 +1,386 @@
+# Feature Parity — Build Order DAG
+
+This document defines the dependency graph and implementation steps for all 14 feature-parity issues. Features are grouped into waves that can execute in parallel. Within each wave, independent features can be built by separate agents simultaneously.
+
+## Dependency Graph
+
+```
+Wave 0 (foundations — no dependencies)
+├── #14 Standalone Secrets Management
+├── #11 Extended Thinking / Reasoning Content Preservation
+└── #1  Graceful Max-Iteration Exhaustion
+
+Wave 1 (depends on Wave 0)
+├── #4  Sub-Agent LLM                          (depends on: #14 for secret resolution)
+├── #2  Event Emission / Lifecycle Hooks        (no hard deps, but Wave 0 clears the agent loop)
+├── #12 Dynamic System Prompt Provider          (no hard deps, touches agent loop)
+└── #3  Multi-Tool Architecture                 (no hard deps, major registry refactor)
+
+Wave 2 (depends on Wave 1)
+├── #7  Built-In Web Tools                      (depends on: #3 native tools, #14 secrets)
+├── #6  Outbound Notification Tool              (depends on: #3 native tools, #14 secrets)
+├── #9  Image Viewing Tool                      (depends on: #3 native tools + content block support)
+├── #8  Summarization Tool                      (depends on: #3 native tools, #4 sub-agent)
+└── #5  Auto-Generated Session Titles           (depends on: #4 sub-agent)
+
+Wave 3 (depends on Wave 2)
+├── #10 Custom Tool Creation + Approval         (depends on: #3 multi-tool, #14 secrets)
+└── #13 Multi-Screen TUI                        (depends on: #2 events, #5 titles, #14 secrets, #10 custom tools)
+```
+
+## Edge List (for tooling)
+
+```
+#4  → #14
+#7  → #3, #14
+#6  → #3, #14
+#9  → #3
+#8  → #3, #4
+#5  → #4
+#10 → #3, #14
+#13 → #2, #5, #10, #14
+```
+
+---
+
+## Wave 0 — Foundations
+
+### #14 Standalone Secrets Management
+
+**Status:** Mostly done. `src/secrets/manager.ts` already implements the full `SecretManager` interface (listKeys, get, set, remove, resolve). Stored at `data/secrets.json`.
+
+**Remaining work:**
+1. Verify the existing `SecretManager` type is exported and usable by new consumers (web tools, notification tool, custom tools)
+2. Add `save()` returning a `Promise<void>` that callers can await (currently fire-and-forget)
+3. Add integration test: create manager, set/get/remove/resolve secrets, verify JSON file on disk
+4. No TUI work yet — that's #13
+
+**Files touched:** `src/secrets/manager.ts`, `src/secrets/index.ts`, new test file
+
+---
+
+### #11 Extended Thinking / Reasoning Content Preservation
+
+**Steps:**
+1. Add `ReasoningBlock` to model types: `{ type: 'thinking'; thinking: string }` in `src/model/types.ts`
+2. Add `reasoning_content?: string` field to `ModelResponse` in `src/model/types.ts`
+3. Update each model provider to extract reasoning content from API responses:
+   - `src/model/anthropic.ts` — extract from `thinking` content blocks
+   - `src/model/openrouter.ts` — extract from response metadata / reasoning field
+   - `src/model/openai-compat.ts` — extract if present (o1-style reasoning)
+   - `src/model/ollama.ts` — no-op (local models don't emit reasoning)
+4. In `src/agent/agent.ts`, after building `assistantMessage`, attach `reasoning_content` if present — store it on the message object (extend `Message` type or use a side map)
+5. Update `src/agent/compaction.ts` `formatConversation()` to include reasoning content when serializing for compaction
+6. Add test: mock model response with reasoning → verify it's stored on the assistant message in history
+
+**Files touched:** `src/model/types.ts`, `src/model/anthropic.ts`, `src/model/openrouter.ts`, `src/model/openai-compat.ts`, `src/agent/agent.ts`, `src/agent/compaction.ts`
+
+---
+
+### #1 Graceful Max-Iteration Exhaustion
+
+**Steps:**
+1. In `src/agent/agent.ts`, after the `for` loop (line ~233), detect whether the loop exited because `round === maxToolRounds` (vs. `end_turn`/`max_tokens`)
+2. If exhausted: push a system-style user message `[System: Max tool calls reached. Provide final response now.]` to history
+3. Make one final `deps.model.complete()` call with `tools: []` (no tools available)
+4. Accumulate usage stats from this final call into `totalInputTokens`, `totalOutputTokens`, increment `rounds`
+5. Push the final assistant response to history
+6. Existing text extraction logic at line ~236 handles the rest
+7. Add test: mock model that always returns `tool_use` → verify final forced response after maxToolRounds
+
+**Files touched:** `src/agent/agent.ts`
+
+**Implementation detail:** Track a `let exitedNormally = false` flag. Set it true inside the `end_turn`/`max_tokens` break. After the for-loop, check `if (!exitedNormally)`.
+
+---
+
+## Wave 1 — Core Infrastructure
+
+### #4 Sub-Agent LLM
+
+**Steps:**
+1. Add sub-model config types to `src/config/types.ts`:
+   ```
+   SubModelConfig {
+     provider: 'anthropic' | 'openai-compat';
+     name: string;
+     maxTokens: number;     // default 8000
+     baseUrl?: string;
+     apiKey?: string;
+   }
+   ```
+   Add `subModel?: SubModelConfig` to `AppConfig`.
+2. Add TOML keys `[sub_model]` to `src/config/loader.ts` with env overrides (`SUB_MODEL_NAME`, `SUB_MODEL_API_KEY`, etc.)
+3. Create `src/model/sub-agent.ts` — a lightweight wrapper:
+   - Takes `SubModelConfig`
+   - Implements a simple `complete(prompt: string, system?: string): Promise<string>` (text in, text out — not `ModelProvider`)
+   - Uses Anthropic SDK or fetch-based OpenAI-compat call
+   - Falls back to the main `ModelProvider` if sub-model not configured
+4. Export a `SubAgentLLM` type from `src/model/sub-agent.ts`
+5. Wire up in `src/index.ts`: create `SubAgentLLM` from config, pass into `AgentDependencies`
+6. Add `subAgent?: SubAgentLLM` to `AgentDependencies` in `src/agent/types.ts`
+7. Update compaction (`src/agent/compaction.ts`) to prefer sub-agent for summarization when available
+8. Add test: sub-agent with mocked provider returns expected text
+
+**Files touched:** `src/config/types.ts`, `src/config/loader.ts`, `src/model/sub-agent.ts` (new), `src/agent/types.ts`, `src/agent/compaction.ts`, `src/index.ts`
+
+---
+
+### #2 Event Emission / Lifecycle Hooks
+
+**Steps:**
+1. Define event types in `src/agent/types.ts`:
+   ```
+   type AgentEventKind = 'llm_start' | 'llm_done' | 'tool_start' | 'tool_done';
+   type AgentEvent = { kind: AgentEventKind; data: Record<string, unknown> };
+   ```
+2. Add `onEvent?: (event: AgentEvent) => Promise<void>` to `ChatOptions`
+3. In `src/agent/agent.ts`, create a helper `const emit = async (kind, data) => { if (options?.onEvent) await options.onEvent({ kind, data }); };`
+4. Emit events at four points in the tool loop:
+   - Before `deps.model.complete()`: `emit('llm_start', { round })`
+   - After `deps.model.complete()`: `emit('llm_done', { round, usage: response.usage, stop_reason: response.stop_reason })`
+   - Before `deps.runtime.execute()`: `emit('tool_start', { tool: 'execute_code', code: code.slice(0, 500) })`
+   - After `deps.runtime.execute()`: `emit('tool_done', { tool: 'execute_code', success: result.success, preview: (result.output ?? '').slice(0, 200) })`
+5. Add test: provide onEvent callback, run chat with tool use, verify all four event kinds fired in order
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`
+
+---
+
+### #12 Dynamic System Prompt Provider
+
+**Steps:**
+1. Add `systemPromptProvider?: () => Promise<string>` to `AgentDependencies` in `src/agent/types.ts`
+2. In `src/agent/agent.ts` `_chatImpl`, before the existing prompt-building block (lines 96-106), check for `deps.systemPromptProvider`:
+   - If present: call it, catch errors and log + fall back to previous cached prompt
+   - If absent: use existing `buildSystemPrompt()` logic (no change)
+3. Store last-good prompt in a closure variable `let cachedSystemPrompt = ''`
+4. Wire up in `src/index.ts`: create a provider function that calls `buildSystemPrompt()` with fresh data from store (self doc, skills, tool docs, secrets list)
+5. This makes the existing prompt-building logic the *default provider* — same behavior, now hookable
+6. Add test: provider that throws → verify fallback to cached prompt
+
+**Files touched:** `src/agent/types.ts`, `src/agent/agent.ts`, `src/index.ts`
+
+---
+
+### #3 Multi-Tool Architecture
+
+**REVISED:** Keep `execute_code` as primary dispatch. Native tool_use only for tools where the result format demands it (images) or sandbox adds no value (notify, summarize). Existing 8 tools stay sandbox-only. See `docs/projects/3/design.md` for full rationale.
+
+**Steps:**
+1. **Extend ToolRegistry** (`src/runtime/tool-registry.ts`):
+   - Add `mode: 'sandbox' | 'native' | 'both'` per tool entry
+   - Add `generateToolDefinitions(): ToolDefinition[]` — returns definitions for native/both-mode tools only
+   - Existing `generateTypeScriptStubs()` generates stubs for sandbox/both-mode tools only
+   - Existing `generateToolDocumentation()` documents ALL tools regardless of mode
+
+2. **Update agent loop** (`src/agent/agent.ts`):
+   - Build tool list: `[EXECUTE_CODE_TOOL, ...registry.generateToolDefinitions()]`
+   - When dispatching `tool_use` blocks, check tool name:
+     - If `execute_code`: existing Deno sandbox path (unchanged)
+     - If any other registered tool: call `registry.execute(name, input)` directly
+   - Add `formatNativeToolResult()` helper for image content block support
+
+3. **Update model types** (`src/model/types.ts`):
+   - Widen `ToolResultBlock.content` to `string | Array<ContentBlock>`
+
+4. **Existing tools unchanged** — all 8 remain `mode: 'sandbox'`
+
+5. **Native tools (added by later features):**
+   - `view_image` (#9) — `mode: 'native'` (image content blocks)
+   - `notify_discord` (#6) — `mode: 'both'` (native + sandbox for scheduled tasks)
+   - `summarize` (#8) — `mode: 'both'` (native + sandbox for composition)
+
+**Files touched:** `src/runtime/tool-registry.ts`, `src/agent/agent.ts`, `src/model/types.ts`
+
+---
+
+## Wave 2 — Tools and Features
+
+### #7 Built-In Web Tools
+
+**Steps:**
+1. Create `src/tools/web.ts` with three tool definitions:
+   - `web_search` — calls Exa search API (`api.exa.ai/search`)
+   - `fetch_page` — calls Exa contents API (`api.exa.ai/contents`)
+   - `http_get` — plain `fetch()` GET request
+2. Each returns structured JSON results (title, url, snippet, score for search; text + metadata for fetch)
+3. Register all three in `src/agent/tools.ts` via `createAgentTools()` — conditionally based on Exa API key availability
+4. Exa API key resolution: check `deps.secrets?.get('EXA_API_KEY')` then fall back to `process.env.EXA_API_KEY`
+5. `http_get` always available (no API key needed). `web_search` and `fetch_page` return clear error if no Exa key
+6. Add `mode: 'native'` so these are exposed as direct tool_use definitions
+7. Truncation: `max_chars` param (default 10000, cap 50000) for `fetch_page` and `http_get`
+8. Add tests: mock fetch responses, verify structured output
+
+**Files touched:** `src/tools/web.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #6 Outbound Notification Tool (Discord Webhook)
+
+**Steps:**
+1. Create `src/tools/notify.ts` with `notify_discord` tool definition
+2. Parameters: `content` (required string), `title` (optional string)
+3. Implementation:
+   - Get webhook URL from `deps.secrets?.get('DISCORD_WEBHOOK_URL')`
+   - If missing: return error message
+   - If `title` provided: POST JSON with `embeds: [{ title, description: content.slice(0, 2000) }]`
+   - Otherwise: POST JSON with `content: content.slice(0, 2000)`
+4. Register in `src/agent/tools.ts` with `mode: 'native'`
+5. Add test: mock fetch, verify correct webhook payload shape for plain and embed modes
+
+**Files touched:** `src/tools/notify.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #9 Image Viewing Tool
+
+**Steps:**
+1. Create `src/tools/image.ts` with `view_image` tool definition
+2. Parameters: `url` (required string)
+3. Implementation:
+   - `fetch(url)` with timeout
+   - Validate `content-type` starts with `image/`
+   - Reject if `content-length > 10MB`
+   - Read body as `ArrayBuffer`, convert to base64
+   - Return structured result: `{ type: 'image_result', text: 'Image from <url>', image: { type: 'base64', media_type, data } }`
+4. Update agent loop tool result handling in `src/agent/agent.ts`:
+   - When a native tool returns an object with `type: 'image_result'`, format the `ToolResultBlock` content as an array containing both a text block and an Anthropic image block
+   - This requires the `ToolResultBlock.content` update from #3
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock fetch returning PNG bytes → verify base64 encoding and content block structure
+
+**Files touched:** `src/tools/image.ts` (new), `src/agent/tools.ts`, `src/agent/agent.ts` (tool result formatting)
+
+---
+
+### #8 Summarization Tool (via Sub-Agent)
+
+**Steps:**
+1. Create `src/tools/summarize.ts` with `summarize` tool definition
+2. Parameters: `text` (required), `instructions` (optional), `max_length` (optional, enum short/medium/long)
+3. Implementation:
+   - Truncate input at 100k chars
+   - Map `max_length` to guidance string
+   - Call `deps.subAgent.complete(prompt, system)` with summarization system prompt
+   - Return `{ summary: result }`
+4. Guard: if `deps.subAgent` is undefined, return error "Sub-agent LLM not configured"
+5. Register in `src/agent/tools.ts` with `mode: 'native'`
+6. Add test: mock sub-agent, verify prompt construction and result
+
+**Files touched:** `src/tools/summarize.ts` (new), `src/agent/tools.ts`
+
+---
+
+### #5 Auto-Generated Session Titles
+
+**Steps:**
+1. Create `src/agent/session-title.ts`:
+   - `maybeGenerateSessionTitle(store, sessionId, subAgent, messages)` function
+   - Guard: skip if session already has a title, < 2 user messages, or no sub-agent
+   - Take first 10 messages, format as text
+   - Call sub-agent with title generation prompt
+   - Post-process: strip quotes, take first line, cap at 80 chars
+   - Persist via `store.updateSessionTitle(sessionId, title)`
+2. Call from `src/agent/agent.ts` at the end of `_chatImpl` (after returning result, non-blocking)
+3. Need session ID available in agent — add `sessionId?: string` to `ChatOptions`
+4. Add test: mock sub-agent returns title → verify store updated
+
+**Files touched:** `src/agent/session-title.ts` (new), `src/agent/agent.ts`, `src/agent/types.ts`
+
+---
+
+## Wave 3 — Integration Features
+
+### #10 Custom Tool Creation + Approval Workflow
+
+**REVISED:** Sandbox-only dispatch. Custom tools are NOT exposed as native tool_use definitions. Called via `tools.call_custom_tool({ name, params })` inside execute_code. See `docs/projects/10/design.md` for rationale (prompt cache invalidation, composition, approval surface simplicity).
+
+**Steps:**
+1. Create `src/tools/custom-tool-manager.ts`:
+   - `CustomTool` type: `{ name, description, parameters (JSON Schema), code (TypeScript), approved, codeHash, secrets: string[] }`
+   - Storage: `customtool:<name>` documents in the store, content is JSON-serialized `CustomTool`
+   - `listTools()`, `getTool(name)`, `saveTool(tool)`, `approveTool(name)`, `revokeTool(name)`
+   - `getApprovedToolSummaries()`: returns `[{ name, description }]` for system prompt listing
+   - Auto-revoke: on `saveTool`, if code or parameters changed (hash mismatch), set `approved = false`
+
+2. Create `src/tools/custom-tools.ts` — agent-facing tools (all `mode: 'sandbox'`):
+   - `create_custom_tool` — agent provides name, description, parameters schema, code, optional secrets list
+   - `list_custom_tools` — returns all custom tools with approval status
+   - `call_custom_tool` — execute an approved custom tool by name (runs code via Deno sandbox with declared secrets injected)
+
+3. Register in `src/agent/tools.ts` with `mode: 'sandbox'`
+
+4. System prompt integration via #12 provider — lists approved custom tool names + descriptions for discoverability
+
+5. Add tests:
+   - Create tool → verify stored as unapproved
+   - Approve → change code → verify auto-revoked
+   - Call approved tool → verify Deno execution with secrets
+
+**Files touched:** `src/tools/custom-tool-manager.ts` (new), `src/tools/custom-tools.ts` (new), `src/agent/tools.ts`, `src/agent/types.ts`, `src/index.ts`
+
+---
+
+### #13 Multi-Screen TUI
+
+This is the largest UI feature. The current TUI is a single `App.tsx` with chat + review pages.
+
+**Steps:**
+1. **Refactor navigation** — replace `page` state string with a screen stack:
+   - Create `src/tui/types.ts` with `Screen = 'sessions' | 'chat' | 'tools' | 'secrets' | 'schedules' | 'prompt' | 'tool-detail'`
+   - Create `src/tui/Navigation.tsx` — manages screen stack, global key bindings
+
+2. **Session List Screen** (`src/tui/screens/SessionListScreen.tsx`):
+   - List sessions from `store.listSessions()` with titles and dates
+   - `n` = new session, `d` = delete, `Enter` = open in chat
+   - Display model name, secret count, tool counts in header
+
+3. **Chat Screen** — refactor from current `App.tsx`:
+   - Wire `onEvent` callback from #2 to show thinking/running indicators
+   - Show token stats bar from `ChatStats`
+   - `Escape` = back to sessions
+
+4. **Tools Screen** (`src/tui/screens/ToolsScreen.tsx`):
+   - List custom tools from `CustomToolManager` (#10)
+   - Show approval status, description
+   - `a` = approve, `r` = revoke, `Enter` = view detail
+   - Also show built-in tools (read-only)
+
+5. **Secrets Screen** (`src/tui/screens/SecretsScreen.tsx`):
+   - List secret names from `SecretManager` (#14)
+   - `a` = add new secret (prompt for name + value), `d` = delete
+   - Never display values after entry
+
+6. **Schedules Screen** (`src/tui/screens/SchedulesScreen.tsx`):
+   - List tasks from scheduler
+   - Show name, schedule, last run time, status
+   - `e` = enable/disable toggle
+
+7. **System Prompt Screen** (`src/tui/screens/SystemPromptScreen.tsx`):
+   - Display current assembled system prompt (read-only, scrollable)
+   - Useful for debugging what the agent sees
+
+8. **Global navigation keys:** `t` = tools, `s` = secrets, `c` = schedules, `p` = prompt, `q` = quit
+   - These work from any screen
+
+9. **Wire props:** Update `src/index.ts` `startTUI()` to pass scheduler, custom tool manager, and all dependencies
+
+10. Add basic rendering tests for each screen component
+
+**Files touched:** `src/tui/App.tsx` (major refactor), `src/tui/types.ts` (new), `src/tui/Navigation.tsx` (new), `src/tui/screens/` (6 new files), `src/tui/index.ts`, `src/index.ts`
+
+---
+
+## Parallel Execution Plan
+
+```
+Time →
+
+Agent A:  [#14 secrets]──────[#4 sub-agent]────────[#8 summarize]──[#10 custom tools]
+Agent B:  [#11 reasoning]────[#2 events]───────────[#5 titles]─────[#13 TUI]────────→
+Agent C:  [#1 max-iter]──────[#3 multi-tool]───────[#7 web tools]──────────────────→
+Agent D:                     [#12 prompt provider]─[#6 notify]─────[#9 image]──────→
+```
+
+**Merge gates:** Each wave must pass tests before the next wave starts consuming its outputs. Within a wave, agents work on isolated file sets and merge to a shared integration branch at wave boundaries.

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,280 @@
+// pattern: Imperative Shell — agent loop tests with mocked dependencies
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createAgent } from './agent.ts';
+import type { AgentConfig, AgentDependencies } from './types.ts';
+import type { Message, ModelProvider, ModelRequest, ModelResponse } from '../model/types.ts';
+import type { CodeRuntime } from '../runtime/types.ts';
+import type { Store, DocumentRow } from '../store/store.ts';
+
+type ModelCall = {
+  request: ModelRequest;
+  toolsCount: number;
+};
+
+function makeStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string) => null as DocumentRow | null,
+    docList: (_limit?: number, _cursor?: string) => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    listMessages: () => [],
+    deleteSession: () => false,
+    saveTask: () => {},
+    getTask: () => null,
+    listTasks: () => [],
+    deleteTask: () => false,
+    updateTaskRun: () => {},
+    grantUpsert: () => {},
+    grantGet: () => null,
+    grantList: () => [],
+    grantDelete: () => false,
+    close: () => {},
+  } as unknown as Store;
+}
+
+function makeRuntime(): CodeRuntime {
+  return {
+    execute: async () => ({
+      success: true,
+      output: 'ok',
+      error: null,
+      duration_ms: 0,
+    }),
+  };
+}
+
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    model: 'test-model',
+    maxTokens: 1024,
+    maxToolRounds: 2,
+    contextBudget: 0.9,
+    contextLimit: 100_000,
+    modelTimeout: 30_000,
+    temperature: 0,
+    timezone: 'UTC',
+    ...overrides,
+  };
+}
+
+function makeDeps(model: ModelProvider, config: AgentConfig, personaPath: string): AgentDependencies {
+  return {
+    model,
+    runtime: makeRuntime(),
+    config,
+    personaPath,
+    store: makeStore(),
+  };
+}
+
+let personaPath: string;
+let tempDir: string;
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'agent-test-'));
+  personaPath = join(tempDir, 'persona.md');
+  await Bun.write(personaPath, '# Test Persona\nYou are a test agent.');
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('graceful max-iteration exhaustion', () => {
+  test('GH01.AC1.1: system nudge appears in history when maxToolRounds exhausted', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 5, output_tokens: 3 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 4 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    const overrideHistory = (result as unknown as { history?: Message[] }).history;
+    expect(overrideHistory).toBeUndefined();
+
+    expect(calls.length).toBe(3);
+    expect(calls[2]?.toolsCount).toBe(0);
+
+    expect(result.text).toBe('Forced wrap-up response');
+  });
+
+  test('GH01.AC2.1: final call uses tools: [] and produces text', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Final text' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.text).toBe('Final text');
+    const finalCall = calls[calls.length - 1];
+    expect(finalCall?.request.tools).toEqual([]);
+  });
+
+  test('GH01.AC2.2: usage stats include the forced final call', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'final' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 7, output_tokens: 11 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'x', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 13, output_tokens: 17 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 2 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    // 2 loop rounds (13+17 each) + 1 forced (7+11)
+    expect(result.stats.inputTokens).toBe(13 + 13 + 7);
+    expect(result.stats.outputTokens).toBe(17 + 17 + 11);
+  });
+
+  test('GH01.AC2.3: rounds count includes the final call (maxToolRounds + 1)', async () => {
+    const model: ModelProvider = {
+      complete: async (req) => {
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'done' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 1, output_tokens: 1 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: 'y', name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 1, output_tokens: 1 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(result.stats.rounds).toBe(4);
+  });
+
+  test('GH01.AC3.1: normal end_turn exit injects no nudge and makes one call', async () => {
+    let callCount = 0;
+    const model: ModelProvider = {
+      complete: async (_req) => {
+        callCount++;
+        return {
+          content: [{ type: 'text', text: 'hi' }],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 4, output_tokens: 2 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 5 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('hello');
+
+    expect(callCount).toBe(1);
+    expect(result.text).toBe('hi');
+    expect(result.stats.rounds).toBe(1);
+    expect(result.stats.inputTokens).toBe(4);
+    expect(result.stats.outputTokens).toBe(2);
+  });
+
+  test('GH01.AC4.1: end-to-end always-tool_use model produces forced text response', async () => {
+    const calls: ModelCall[] = [];
+    const model: ModelProvider = {
+      complete: async (req) => {
+        calls.push({ request: req, toolsCount: req.tools?.length ?? 0 });
+        if ((req.tools?.length ?? 0) === 0) {
+          return {
+            content: [{ type: 'text', text: 'Forced wrap-up response' }],
+            stop_reason: 'end_turn',
+            usage: { input_tokens: 9, output_tokens: 6 },
+          };
+        }
+        return {
+          content: [{ type: 'tool_use', id: `t${calls.length}`, name: 'execute_code', input: { code: 'output(1)' } }],
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      },
+    };
+
+    const config = makeConfig({ maxToolRounds: 3 });
+    const agent = createAgent(makeDeps(model, config, personaPath));
+    const result = await agent.chat('please do work');
+
+    expect(result.text).toBe('Forced wrap-up response');
+    expect(result.stats.rounds).toBe(4);
+    expect(result.stats.inputTokens).toBe(10 * 3 + 9);
+    expect(result.stats.outputTokens).toBe(5 * 3 + 6);
+
+    // Verify calls 1..3 had tools, final had tools: []
+    expect(calls.length).toBe(4);
+    expect(calls[0]?.toolsCount).toBe(1);
+    expect(calls[1]?.toolsCount).toBe(1);
+    expect(calls[2]?.toolsCount).toBe(1);
+    expect(calls[3]?.toolsCount).toBe(0);
+
+    // Verify nudge user message exists in the request sent on the final call.
+    const finalReq = calls[3]?.request;
+    const nudgeMessage = finalReq?.messages.find(
+      (m) => m.role === 'user' && m.content === '[System: Max tool calls reached. Provide final response now.]',
+    );
+    expect(nudgeMessage).toBeDefined();
+  });
+});

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -1,0 +1,184 @@
+// pattern: Imperative Shell (test) — exercises agent loop with mocks
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createAgent } from './agent.ts';
+import type { ModelResponse, Message, ModelRequest } from '../model/types.ts';
+import type { AgentDependencies } from './types.ts';
+import type { Store, DocumentRow, GrantRow } from '../store/store.ts';
+import type { CodeRuntime, ExecutionResult } from '../runtime/types.ts';
+
+function createNoopStore(): Store {
+  return {
+    docUpsert: () => {},
+    docGet: (_rkey: string): DocumentRow | null => null,
+    docList: () => ({ documents: [], cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    getMessages: () => [],
+    clearMessages: () => {},
+    saveTask: () => {},
+    listTasks: () => [],
+    getTask: () => null,
+    updateTaskRun: () => {},
+    deleteTask: () => false,
+    saveGrant: () => {},
+    getGrant: (): GrantRow | null => null,
+    listGrants: () => [],
+    updateGrantStatus: () => {},
+    updateGrantSecrets: () => {},
+    deleteGrant: () => false,
+    close: () => {},
+  };
+}
+
+const noopRuntime: CodeRuntime = {
+  async execute(): Promise<ExecutionResult> {
+    return { success: true, output: '', error: null, duration_ms: 0 };
+  },
+};
+
+describe('agent reasoning_content propagation', () => {
+  let tmpDir: string;
+  let personaPath: string;
+
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'gh11-agent-test-'));
+    personaPath = join(tmpDir, 'persona.md');
+    writeFileSync(personaPath, '# Test Persona\nYou are a test agent.');
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('reasoning_content from model response appears on history message sent to next call', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'I have responded.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+        reasoning_content: 'Let me think step by step about this problem.',
+      },
+      {
+        content: [{ type: 'text', text: 'Second response.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+
+    const first = await agent.chat('first user message');
+    expect(first.text).toBe('I have responded.');
+
+    await agent.chat('second user message');
+
+    // The second call's messages should include the assistant message from the first call.
+    // That assistant message must carry reasoning_content.
+    const secondCallMessages = receivedMessages[1];
+    expect(secondCallMessages).toBeDefined();
+
+    const assistantMessage = secondCallMessages!.find(
+      (m) => m.role === 'assistant',
+    );
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBe(
+      'Let me think step by step about this problem.',
+    );
+  });
+
+  test('absent reasoning_content does not pollute the assistant history message', async () => {
+    const receivedMessages: ReadonlyArray<Message>[] = [];
+
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'text', text: 'No reasoning here.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      {
+        content: [{ type: 'text', text: 'Done.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    let callIndex = 0;
+    const mockModel = {
+      async complete(request: Readonly<ModelRequest>): Promise<ModelResponse> {
+        receivedMessages.push(request.messages);
+        const response = responses[callIndex];
+        callIndex++;
+        if (!response) throw new Error('Unexpected extra model call');
+        return response;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: noopRuntime,
+      config: {
+        model: 'mock-model',
+        maxTokens: 100,
+        maxToolRounds: 3,
+        contextBudget: 0.9,
+        contextLimit: 100_000,
+        modelTimeout: 30_000,
+        timezone: 'UTC',
+      },
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+    await agent.chat('first');
+    await agent.chat('second');
+
+    const secondCallMessages = receivedMessages[1];
+    const assistantMessage = secondCallMessages!.find((m) => m.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.reasoning_content).toBeUndefined();
+  });
+});

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -4,13 +4,14 @@ import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createAgent } from './agent.ts';
+import { createAgent, formatNativeToolResult } from './agent.ts';
 import type { AgentConfig, AgentDependencies } from './types.ts';
 import type {
   Message,
   ModelProvider,
   ModelRequest,
   ModelResponse,
+  ToolResultContentBlock,
 } from '../model/types.ts';
 import type { CodeRuntime, ExecutionResult } from '../runtime/types.ts';
 import type { Store, DocumentRow, GrantRow } from '../store/store.ts';
@@ -378,5 +379,186 @@ describe('graceful max-iteration exhaustion', () => {
       (m) => m.role === 'user' && m.content === '[System: Max tool calls reached. Provide final response now.]',
     );
     expect(nudgeMessage).toBeDefined();
+  });
+});
+
+describe('agent loop tool dispatch routing', () => {
+  let tmpDir3: string;
+  let personaPath: string;
+
+  beforeAll(() => {
+    tmpDir3 = mkdtempSync(join(tmpdir(), 'gh03-agent-test-'));
+    personaPath = join(tmpDir3, 'persona.md');
+    writeFileSync(personaPath, '# Test Persona\nYou are a test agent.');
+  });
+
+  afterAll(() => {
+    rmSync(tmpDir3, { recursive: true, force: true });
+  });
+
+  test('GH03.AC6.1 / GH03.AC11.1: execute_code tool_use dispatches through Deno sandbox runtime', async () => {
+    const runtimeCalls: Array<{ code: string }> = [];
+    const recordingRuntime: CodeRuntime = {
+      async execute(code: string): Promise<ExecutionResult> {
+        runtimeCalls.push({ code });
+        return { success: true, output: 'hello', error: null, duration_ms: 1 };
+      },
+    };
+
+    let callIndex = 0;
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'tool_use', id: 'tu1', name: 'execute_code', input: { code: 'output("hello")' } }],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      {
+        content: [{ type: 'text', text: 'Done — got hello.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    const mockModel: ModelProvider = {
+      async complete(_req: Readonly<ModelRequest>): Promise<ModelResponse> {
+        const r = responses[callIndex++];
+        if (!r) throw new Error('Unexpected extra model call');
+        return r;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: recordingRuntime,
+      config: makeConfig({ maxToolRounds: 5 }),
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+    const result = await agent.chat('please run hello');
+
+    expect(runtimeCalls.length).toBe(1);
+    expect(runtimeCalls[0]?.code).toBe('output("hello")');
+    expect(result.text).toBe('Done — got hello.');
+  });
+
+  test('GH03.AC5.1 / GH03.AC10.1: non-execute_code tool_use bypasses sandbox and goes through registry', async () => {
+    const runtimeCalls: Array<{ code: string }> = [];
+    const recordingRuntime: CodeRuntime = {
+      async execute(code: string): Promise<ExecutionResult> {
+        runtimeCalls.push({ code });
+        return { success: true, output: 'should not happen', error: null, duration_ms: 1 };
+      },
+    };
+
+    const modelCalls: ReadonlyArray<Message>[] = [];
+    let callIndex = 0;
+    const responses: ModelResponse[] = [
+      {
+        content: [{ type: 'tool_use', id: 'tu1', name: 'some_native_tool', input: { x: 1 } }],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+      {
+        content: [{ type: 'text', text: 'Acknowledged the error.' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 12, output_tokens: 4 },
+      },
+    ];
+
+    const mockModel: ModelProvider = {
+      async complete(req: Readonly<ModelRequest>): Promise<ModelResponse> {
+        modelCalls.push(req.messages);
+        const r = responses[callIndex++];
+        if (!r) throw new Error('Unexpected extra model call');
+        return r;
+      },
+    };
+
+    const deps: AgentDependencies = {
+      model: mockModel,
+      runtime: recordingRuntime,
+      config: makeConfig({ maxToolRounds: 5 }),
+      personaPath,
+      store: createNoopStore(),
+    };
+
+    const agent = createAgent(deps);
+    const result = await agent.chat('call the native tool');
+
+    expect(runtimeCalls.length).toBe(0);
+
+    const secondCallMessages = modelCalls[1];
+    expect(secondCallMessages).toBeDefined();
+
+    const toolResultMsg = secondCallMessages!.find(
+      (m) =>
+        m.role === 'user' &&
+        Array.isArray(m.content) &&
+        m.content.some((b) => b.type === 'tool_result' && b.tool_use_id === 'tu1'),
+    );
+    expect(toolResultMsg).toBeDefined();
+
+    const blocks = toolResultMsg!.content as ReadonlyArray<{
+      type: string;
+      tool_use_id: string;
+      content: unknown;
+      is_error?: boolean;
+    }>;
+    const resultBlock = blocks.find((b) => b.type === 'tool_result' && b.tool_use_id === 'tu1');
+    expect(resultBlock).toBeDefined();
+    expect(resultBlock!.is_error).toBe(true);
+    expect(resultBlock!.content).toContain('Tool error');
+    expect(resultBlock!.content).toContain('Unknown tool: some_native_tool');
+
+    expect(result.text).toBe('Acknowledged the error.');
+  });
+});
+
+describe('formatNativeToolResult', () => {
+  test('string result is used directly as content', () => {
+    const block = formatNativeToolResult('id1', 'hello');
+    expect(block.type).toBe('tool_result');
+    expect(block.tool_use_id).toBe('id1');
+    expect(block.content).toBe('hello');
+    expect(block.is_error).toBeUndefined();
+  });
+
+  test('object result is JSON.stringified', () => {
+    const block = formatNativeToolResult('id1', { key: 'value', n: 7 });
+    expect(block.content).toBe(JSON.stringify({ key: 'value', n: 7 }));
+  });
+
+  test('undefined result is rendered as (no output)', () => {
+    const block = formatNativeToolResult('id1', undefined);
+    expect(block.content).toBe('(no output)');
+  });
+
+  test('image_result with text and image returns array content with text + data URI image block', () => {
+    const block = formatNativeToolResult('id1', {
+      type: 'image_result',
+      text: 'An image',
+      image: { data: 'base64data', media_type: 'image/png' },
+    });
+    expect(Array.isArray(block.content)).toBe(true);
+    const blocks = block.content as ToolResultContentBlock[];
+    expect(blocks.length).toBe(2);
+    expect(blocks[0]).toEqual({ type: 'text', text: 'An image' });
+    expect(blocks[1]).toEqual({
+      type: 'image_url',
+      image_url: { url: 'data:image/png;base64,base64data' },
+    });
+  });
+
+  test('image_result with missing image returns array content with just the text block', () => {
+    const block = formatNativeToolResult('id1', {
+      type: 'image_result',
+      text: 'An image',
+    });
+    expect(Array.isArray(block.content)).toBe(true);
+    const blocks = block.content as ToolResultContentBlock[];
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]).toEqual({ type: 'text', text: 'An image' });
   });
 });

--- a/src/agent/agent.test.ts
+++ b/src/agent/agent.test.ts
@@ -368,9 +368,10 @@ describe('graceful max-iteration exhaustion', () => {
     expect(result.stats.outputTokens).toBe(5 * 3 + 6);
 
     expect(calls.length).toBe(4);
-    expect(calls[0]?.toolsCount).toBe(1);
-    expect(calls[1]?.toolsCount).toBe(1);
-    expect(calls[2]?.toolsCount).toBe(1);
+    const initialToolsCount = calls[0]?.toolsCount ?? 0;
+    expect(initialToolsCount).toBeGreaterThan(0);
+    expect(calls[1]?.toolsCount).toBe(initialToolsCount);
+    expect(calls[2]?.toolsCount).toBe(initialToolsCount);
     expect(calls[3]?.toolsCount).toBe(0);
 
     const finalReq = calls[3]?.request;

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -134,9 +134,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
     if (needsCompaction(history, systemPrompt, deps.config.contextLimit, deps.config.contextBudget)) {
       const compacted = await compactContext(history, {
         store: deps.store,
-        model: deps.model,
-        modelName: deps.config.model,
-        maxTokens: deps.config.maxTokens,
+        subAgent: deps.subAgent!,
       });
       // Replace history with compacted context + current user message
       const currentMessage = history[history.length - 1];

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -48,7 +48,7 @@ Full tool reference with all available functions and their parameters is in your
   },
 };
 
-function formatNativeToolResult(
+export function formatNativeToolResult(
   toolUseId: string,
   result: unknown,
 ): ToolResultBlock {

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -5,6 +5,7 @@ import type {
   Message,
   ToolUseBlock,
   ToolResultBlock,
+  ToolResultContentBlock,
   ToolDefinition,
   ContentBlock,
 } from '../model/types.ts';
@@ -46,6 +47,44 @@ Full tool reference with all available functions and their parameters is in your
     required: ['code'],
   },
 };
+
+function formatNativeToolResult(
+  toolUseId: string,
+  result: unknown,
+): ToolResultBlock {
+  if (typeof result === 'string') {
+    return { type: 'tool_result', tool_use_id: toolUseId, content: result };
+  }
+
+  if (
+    result !== null &&
+    typeof result === 'object' &&
+    'type' in result &&
+    (result as Record<string, unknown>).type === 'image_result'
+  ) {
+    const r = result as Record<string, unknown>;
+    const blocks: Array<ToolResultContentBlock> = [];
+
+    if (typeof r.text === 'string') {
+      blocks.push({ type: 'text', text: r.text });
+    }
+
+    if (r.image && typeof r.image === 'object') {
+      const img = r.image as Record<string, unknown>;
+      if (typeof img.data === 'string' && typeof img.media_type === 'string') {
+        const dataUri = `data:${img.media_type};base64,${img.data}`;
+        blocks.push({ type: 'image_url', image_url: { url: dataUri } });
+      }
+    }
+
+    if (blocks.length > 0) {
+      return { type: 'tool_result', tool_use_id: toolUseId, content: blocks };
+    }
+  }
+
+  const serialized = typeof result === 'undefined' ? '(no output)' : JSON.stringify(result);
+  return { type: 'tool_result', tool_use_id: toolUseId, content: serialized };
+}
 
 export function createAgent(deps: Readonly<AgentDependencies>): Agent {
   let history: Array<Message> = [];
@@ -91,6 +130,9 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
 
     // Generate tool docs for system prompt
     const toolDocs = registry.generateToolDocumentation();
+
+    // Native tools that the model invokes directly (not through execute_code)
+    const nativeTools = registry.generateToolDefinitions();
 
     // a. Read persona
     const persona = await Bun.file(deps.personaPath).text();
@@ -152,7 +194,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
         response = await deps.model.complete({
           system: systemPrompt,
           messages: history,
-          tools: [EXECUTE_CODE_TOOL],
+          tools: [EXECUTE_CODE_TOOL, ...nativeTools],
           model: deps.config.model,
           max_tokens: deps.config.maxTokens,
           temperature: deps.config.temperature,
@@ -205,21 +247,26 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
           const toolResults: Array<ToolResultBlock> = await Promise.all(
             toolUseBlocks.map(async (block): Promise<ToolResultBlock> => {
               try {
-                const code = (block.input as Record<string, unknown>)['code'];
-                if (typeof code !== 'string') {
-                  return { type: 'tool_result', tool_use_id: block.id, content: 'Error: missing code parameter', is_error: true };
+                if (block.name === 'execute_code') {
+                  const code = (block.input as Record<string, unknown>)['code'];
+                  if (typeof code !== 'string') {
+                    return { type: 'tool_result', tool_use_id: block.id, content: 'Error: missing code parameter', is_error: true };
+                  }
+
+                  // IPC callback: dispatch tool calls from the sandbox through the registry
+                  const onToolCall = async (name: string, params: Record<string, unknown>): Promise<unknown> => {
+                    return registry.execute(name, params);
+                  };
+
+                  const result = await deps.runtime.execute(code, undefined, onToolCall);
+                  const output = result.success
+                    ? result.output || '(no output)'
+                    : `Error: ${result.error ?? 'unknown error'}\n${result.output}`;
+                  return { type: 'tool_result', tool_use_id: block.id, content: output, is_error: !result.success };
+                } else {
+                  const result = await registry.execute(block.name, block.input);
+                  return formatNativeToolResult(block.id, result);
                 }
-
-                // IPC callback: dispatch tool calls from the sandbox through the registry
-                const onToolCall = async (name: string, params: Record<string, unknown>): Promise<unknown> => {
-                  return registry.execute(name, params);
-                };
-
-                const result = await deps.runtime.execute(code, undefined, onToolCall);
-                const output = result.success
-                  ? result.output || '(no output)'
-                  : `Error: ${result.error ?? 'unknown error'}\n${result.output}`;
-                return { type: 'tool_result', tool_use_id: block.id, content: output, is_error: !result.success };
               } catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 return { type: 'tool_result', tool_use_id: block.id, content: `Tool error: ${message}`, is_error: true };

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -175,6 +175,9 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
 
       // Append assistant response
       const assistantMessage: Message = { role: 'assistant', content: response.content };
+      if (response.reasoning_content) {
+        assistantMessage.reasoning_content = response.reasoning_content;
+      }
       history.push(assistantMessage);
 
       // Check stop reason

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -145,6 +145,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
     }
 
     // e. Tool loop
+    let exitedNormally = false;
     for (let round = 0; round < deps.config.maxToolRounds; round++) {
       let response;
       try {
@@ -180,6 +181,7 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
       // Check stop reason
       if (response.stop_reason === 'end_turn' || response.stop_reason === 'max_tokens') {
         process.stderr.write(`[agent] loop exiting: ${response.stop_reason}\n`);
+        exitedNormally = true;
         break;
       }
 
@@ -230,6 +232,32 @@ export function createAgent(deps: Readonly<AgentDependencies>): Agent {
           throw new Error(`Tool dispatch failed: ${err instanceof Error ? err.message : err}`);
         }
       }
+    }
+
+    // g. Handle max-iteration exhaustion — force a text-only wrap-up
+    if (!exitedNormally) {
+      process.stderr.write(`[agent] max tool rounds (${deps.config.maxToolRounds}) exhausted, forcing final response\n`);
+
+      history.push({
+        role: 'user',
+        content: '[System: Max tool calls reached. Provide final response now.]',
+      });
+
+      const finalResponse = await deps.model.complete({
+        system: systemPrompt,
+        messages: history,
+        tools: [],
+        model: deps.config.model,
+        max_tokens: deps.config.maxTokens,
+        temperature: deps.config.temperature,
+        timeout: deps.config.modelTimeout,
+      });
+
+      rounds++;
+      totalInputTokens += finalResponse.usage.input_tokens;
+      totalOutputTokens += finalResponse.usage.output_tokens;
+
+      history.push({ role: 'assistant', content: finalResponse.content });
     }
 
     // f. Extract final text from last assistant message

--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -1,0 +1,36 @@
+// pattern: Functional Core (test)
+
+import { describe, test, expect } from 'bun:test';
+import { formatConversation } from './compaction.ts';
+import type { Message } from '../model/types.ts';
+
+describe('formatConversation', () => {
+  test('includes reasoning_content when present on assistant message', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'What is 2+2?' },
+      {
+        role: 'assistant',
+        content: 'The answer is 4.',
+        reasoning_content: 'Simple arithmetic: 2+2=4.',
+      },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).toContain('### assistant (reasoning)');
+    expect(result).toContain('Simple arithmetic: 2+2=4.');
+    expect(result).toContain('### assistant\nThe answer is 4.');
+  });
+
+  test('omits reasoning section when reasoning_content is absent', () => {
+    const messages: Message[] = [
+      { role: 'user', content: 'Hello' },
+      { role: 'assistant', content: 'Hi there' },
+    ];
+
+    const result = formatConversation(messages);
+
+    expect(result).not.toContain('(reasoning)');
+    expect(result).toContain('### assistant\nHi there');
+  });
+});

--- a/src/agent/compaction.test.ts
+++ b/src/agent/compaction.test.ts
@@ -1,8 +1,10 @@
 // pattern: Functional Core (test)
 
 import { describe, test, expect } from 'bun:test';
-import { formatConversation } from './compaction.ts';
+import { compactContext, formatConversation } from './compaction.ts';
 import type { Message } from '../model/types.ts';
+import type { SubAgentLLM } from '../model/sub-agent.ts';
+import type { Store } from '../store/store.ts';
 
 describe('formatConversation', () => {
   test('includes reasoning_content when present on assistant message', () => {
@@ -32,5 +34,98 @@ describe('formatConversation', () => {
 
     expect(result).not.toContain('(reasoning)');
     expect(result).toContain('### assistant\nHi there');
+  });
+});
+
+type SubAgentCall = { prompt: string; system?: string };
+
+function makeMockStore(documents: Array<{ rkey: string; content: string }>): {
+  store: Store;
+  upserts: Array<{ rkey: string; content: string }>;
+} {
+  const upserts: Array<{ rkey: string; content: string }> = [];
+  const docs = [...documents];
+  const store = {
+    docUpsert: (rkey: string, content: string) => {
+      upserts.push({ rkey, content });
+      docs.push({ rkey, content });
+    },
+    docGet: () => null,
+    docList: () => ({ documents: docs.slice(), cursor: undefined }),
+    docDelete: () => false,
+    docSearch: () => [],
+    saveEmbedding: () => {},
+    getEmbedding: () => null,
+    getAllEmbeddings: () => [],
+    getStaleEmbeddings: () => [],
+    createSession: () => {},
+    ensureSession: () => {},
+    getSession: () => null,
+    listSessions: () => [],
+    updateSessionTitle: () => {},
+    appendMessage: () => {},
+    getMessages: () => [],
+    clearMessages: () => {},
+    saveTask: () => {},
+    listTasks: () => [],
+    getTask: () => null,
+    updateTaskRun: () => {},
+    deleteTask: () => false,
+    saveGrant: () => {},
+    getGrant: () => null,
+    listGrants: () => [],
+    updateGrantStatus: () => {},
+    updateGrantSecrets: () => {},
+    deleteGrant: () => false,
+    close: () => {},
+  } as unknown as Store;
+  return { store, upserts };
+}
+
+function makeMockSubAgent(response: string): { subAgent: SubAgentLLM; calls: SubAgentCall[] } {
+  const calls: SubAgentCall[] = [];
+  const subAgent: SubAgentLLM = {
+    async complete(prompt: string, system?: string) {
+      calls.push({ prompt, system });
+      return response;
+    },
+  };
+  return { subAgent, calls };
+}
+
+describe('compactContext', () => {
+  test('uses sub-agent for summarization when older context docs exist', async () => {
+    const documents = [
+      { rkey: 'context/2025-01-01T00-00-00', content: 'conversation 1' },
+      { rkey: 'context/2025-01-02T00-00-00', content: 'conversation 2' },
+      { rkey: 'context/2025-01-03T00-00-00', content: 'conversation 3' },
+      { rkey: 'context/2025-01-04T00-00-00', content: 'conversation 4' },
+      { rkey: 'context/2025-01-05T00-00-00', content: 'conversation 5' },
+    ];
+    const { store } = makeMockStore(documents);
+    const { subAgent, calls } = makeMockSubAgent('Earlier topics: weather, coding');
+
+    const messages: Message[] = [{ role: 'user', content: 'hello' }];
+    const result = await compactContext(messages, { store, subAgent });
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.system).toContain('context summarizer');
+
+    const compactionContent = result[0]!.content as string;
+    expect(compactionContent).toContain('Earlier topics: weather, coding');
+  });
+
+  test('skips sub-agent call when there are no older context docs to summarize', async () => {
+    const documents = [
+      { rkey: 'context/2025-01-01T00-00-00', content: 'conversation 1' },
+      { rkey: 'context/2025-01-02T00-00-00', content: 'conversation 2' },
+    ];
+    const { store } = makeMockStore(documents);
+    const { subAgent, calls } = makeMockSubAgent('unused summary');
+
+    const messages: Message[] = [{ role: 'user', content: 'hi' }];
+    await compactContext(messages, { store, subAgent });
+
+    expect(calls.length).toBe(0);
   });
 });

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -16,7 +16,7 @@ const RECENT_NOTES_COUNT = 3;
 /**
  * Format a conversation history as readable markdown.
  */
-function formatConversation(messages: ReadonlyArray<Message>): string {
+export function formatConversation(messages: ReadonlyArray<Message>): string {
   return messages
     .map((msg) => {
       const content =
@@ -32,7 +32,13 @@ function formatConversation(messages: ReadonlyArray<Message>): string {
               })
               .filter(Boolean)
               .join('\n');
-      return `### ${msg.role}\n${content}`;
+
+      const sections: string[] = [];
+      if (msg.reasoning_content) {
+        sections.push(`### ${msg.role} (reasoning)\n${msg.reasoning_content}`);
+      }
+      sections.push(`### ${msg.role}\n${content}`);
+      return sections.join('\n\n');
     })
     .join('\n\n');
 }

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -6,7 +6,8 @@
 // 3. Summarize all older context documents into one paragraph
 // 4. Return rebuilt context for the agent to continue with
 
-import type { Message, ModelProvider } from '../model/types.ts';
+import type { Message } from '../model/types.ts';
+import type { SubAgentLLM } from '../model/sub-agent.ts';
 import type { Store } from '../store/store.ts';
 import { estimateTokens } from './context.ts';
 
@@ -94,33 +95,19 @@ export function needsCompaction(
  * Uses a dedicated LLM call (option A — mechanical, out of the agent's way).
  */
 async function summarizeOlderContext(
-  model: ModelProvider,
-  modelName: string,
-  maxTokens: number,
+  subAgent: SubAgentLLM,
   notes: ReadonlyArray<string>,
 ): Promise<string> {
   if (notes.length === 0) return '';
 
-  // Combine all older notes, truncating each to keep the summary call manageable
   const combined = notes
     .map((text, i) => `--- Context ${i + 1} ---\n${text.slice(0, 3000)}`)
     .join('\n\n');
 
-  const response = await model.complete({
-    system:
-      'You are a context summarizer. Given conversation logs, produce a concise 2-4 sentence summary capturing the key topics discussed, decisions made, and any important facts or preferences revealed. Focus on what would be useful for continuing the conversation. Do not use markdown headers or bullet points — write flowing prose.',
-    messages: [{ role: 'user', content: combined }],
-    tools: [],
-    model: modelName,
-    max_tokens: Math.min(maxTokens, 512),
-  });
+  const system =
+    'You are a context summarizer. Given conversation logs, produce a concise 2-4 sentence summary capturing the key topics discussed, decisions made, and any important facts or preferences revealed. Focus on what would be useful for continuing the conversation. Do not use markdown headers or bullet points — write flowing prose.';
 
-  // Extract text from response
-  const text = response.content
-    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
-    .map((block) => block.text)
-    .join(' ');
-
+  const text = await subAgent.complete(combined, system);
   return text || '(summary unavailable)';
 }
 
@@ -135,9 +122,7 @@ export async function compactContext(
   messages: ReadonlyArray<Message>,
   deps: {
     store: Store;
-    model: ModelProvider;
-    modelName: string;
-    maxTokens: number;
+    subAgent: SubAgentLLM;
   },
 ): Promise<Array<Message>> {
   // 1. Save current conversation
@@ -161,9 +146,7 @@ export async function compactContext(
   let olderSummary = '';
   if (olderDocs.length > 0) {
     olderSummary = await summarizeOlderContext(
-      deps.model,
-      deps.modelName,
-      deps.maxTokens,
+      deps.subAgent,
       olderDocs.map((d) => d.content),
     );
   }

--- a/src/agent/compaction.ts
+++ b/src/agent/compaction.ts
@@ -7,6 +7,7 @@
 // 4. Return rebuilt context for the agent to continue with
 
 import type { Message, ModelProvider } from '../model/types.ts';
+import { toolResultContentToString } from '../model/types.ts';
 import type { Store } from '../store/store.ts';
 import { estimateTokens } from './context.ts';
 
@@ -27,7 +28,7 @@ export function formatConversation(messages: ReadonlyArray<Message>): string {
                 if (block.type === 'text') return block.text;
                 if (block.type === 'image_url') return '[image]';
                 if (block.type === 'tool_use') return `[tool_use: ${block.name}]`;
-                if (block.type === 'tool_result') return `[tool_result: ${block.content?.toString().slice(0, 200) ?? ''}]`;
+                if (block.type === 'tool_result') return `[tool_result: ${toolResultContentToString(block.content).slice(0, 200)}]`;
                 return '';
               })
               .filter(Boolean)

--- a/src/agent/context.ts
+++ b/src/agent/context.ts
@@ -52,7 +52,7 @@ export function buildSystemPrompt(
   }
 
   if (toolDocs) {
-    sections.push('\n\n## `tools` Namespace Reference\n\nThe following methods are available on the `tools` object **only inside TypeScript code you run via `execute_code`.** They are NOT callable as top-level functions. To use any of these, emit an `execute_code` tool call with TypeScript that does `await tools.<method>({...})`.\n');
+    sections.push('\n\n## Tool Reference\n\nTools marked with `tools.<name>` are available **only inside TypeScript code you run via `execute_code`.** Call them as `await tools.<method>({...})`. Tools marked *(direct tool call)* are called directly — do NOT use execute_code for those.\n');
     sections.push(toolDocs);
   }
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -5,19 +5,10 @@ import { randomUUID } from 'node:crypto';
 import { createToolRegistry, type ToolRegistry } from '../runtime/tool-registry.ts';
 import type { AgentDependencies, ChatContext } from './types.ts';
 import type { GrantStatus } from '../store/store.ts';
+import { str, optStr } from '../tools/helpers.ts';
+import { registerSummarizeTools } from '../tools/summarize.ts';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-function str(input: Record<string, unknown>, key: string): string {
-  const val = input[key];
-  if (typeof val !== 'string') throw new Error(`missing required param: ${key}`);
-  return val;
-}
-
-function optStr(input: Record<string, unknown>, key: string, fallback: string = ''): string {
-  const val = input[key];
-  return typeof val === 'string' ? val : fallback;
-}
 
 function hashCode(code: string): string {
   return createHash('sha256').update(code).digest('hex').slice(0, 16);
@@ -323,6 +314,9 @@ For skill documents, include a \`// Description: ...\` header comment. Saving a 
       return `✅ Task ${id} cancelled.`;
     },
   );
+
+  // ── summarize (via sub-agent) ──────────────────────────────────────────
+  registerSummarizeTools(registry, deps);
 
   return registry;
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -7,6 +7,7 @@ import type { VectorStore } from '../search/vector-store.ts';
 import type { TaskStore } from '../scheduler/types.ts';
 import type { Store } from '../store/store.ts';
 import type { SecretManager } from '../secrets/manager.ts';
+import type { SubAgentLLM } from '../model/sub-agent.ts';
 
 export type AgentConfig = {
   readonly model: string;
@@ -43,6 +44,7 @@ export type AgentDependencies = {
   readonly scheduler?: TaskStore;
   readonly store: Store;
   readonly secrets?: SecretManager;
+  readonly subAgent?: SubAgentLLM;
 };
 
 export type ConversationTurn = {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1,0 +1,157 @@
+// pattern: Imperative Shell (test) — config loader [sub_model] parsing
+
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { writeFileSync, unlinkSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { loadConfig } from './loader.ts';
+
+let tempDir: string;
+const SUB_MODEL_ENV_KEYS = [
+  'SUB_MODEL_API_KEY',
+  'SUB_MODEL_PROVIDER',
+  'SUB_MODEL_NAME',
+  'SUB_MODEL_BASE_URL',
+] as const;
+
+function writeTempConfig(toml: string): string {
+  const path = join(tempDir, `config-${Date.now()}-${Math.random().toString(36).slice(2)}.toml`);
+  writeFileSync(path, toml);
+  return path;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'config-test-'));
+  for (const k of SUB_MODEL_ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  for (const k of SUB_MODEL_ENV_KEYS) delete process.env[k];
+});
+
+const BASE_TOML = `
+[model]
+provider = "anthropic"
+name = "claude-sonnet-4-20250514"
+max_tokens = 16384
+api_key = "main-key"
+`;
+
+describe('loadConfig — [sub_model] parsing', () => {
+  test('returns undefined subModel when [sub_model] section is absent', () => {
+    const path = writeTempConfig(BASE_TOML);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel).toBeUndefined();
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('parses full [sub_model] section', () => {
+    const path = writeTempConfig(`
+${BASE_TOML}
+
+[sub_model]
+provider = "anthropic"
+name = "claude-haiku-4-5-20251001"
+max_tokens = 4000
+api_key = "toml-key"
+`);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel).toBeDefined();
+      expect(cfg.subModel!.provider).toBe('anthropic');
+      expect(cfg.subModel!.name).toBe('claude-haiku-4-5-20251001');
+      expect(cfg.subModel!.maxTokens).toBe(4000);
+      expect(cfg.subModel!.apiKey).toBe('toml-key');
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('SUB_MODEL_API_KEY env var overrides TOML api_key', () => {
+    process.env['SUB_MODEL_API_KEY'] = 'env-key';
+    const path = writeTempConfig(`
+${BASE_TOML}
+
+[sub_model]
+provider = "anthropic"
+name = "claude-haiku-4-5-20251001"
+api_key = "toml-key"
+`);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel!.apiKey).toBe('env-key');
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('OpenRouter sub-model gets default base URL when not set', () => {
+    const path = writeTempConfig(`
+${BASE_TOML}
+
+[sub_model]
+provider = "openrouter"
+name = "meta-llama/llama-3-8b"
+api_key = "or-key"
+`);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel!.baseUrl).toBe('https://openrouter.ai/api/v1');
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('SUB_MODEL_PROVIDER env var creates sub-model when TOML lacks one', () => {
+    process.env['SUB_MODEL_PROVIDER'] = 'anthropic';
+    process.env['SUB_MODEL_NAME'] = 'claude-haiku-from-env';
+    process.env['SUB_MODEL_API_KEY'] = 'env-only-key';
+
+    const path = writeTempConfig(BASE_TOML);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel).toBeDefined();
+      expect(cfg.subModel!.provider).toBe('anthropic');
+      expect(cfg.subModel!.name).toBe('claude-haiku-from-env');
+      expect(cfg.subModel!.apiKey).toBe('env-only-key');
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('default name applies when TOML omits name', () => {
+    const path = writeTempConfig(`
+${BASE_TOML}
+
+[sub_model]
+provider = "anthropic"
+api_key = "k"
+`);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel!.name).toBe('claude-haiku-4-5-20251001');
+    } finally {
+      unlinkSync(path);
+    }
+  });
+
+  test('default maxTokens (8000) applies when TOML omits max_tokens', () => {
+    const path = writeTempConfig(`
+${BASE_TOML}
+
+[sub_model]
+provider = "anthropic"
+api_key = "k"
+`);
+    try {
+      const cfg = loadConfig(path);
+      expect(cfg.subModel!.maxTokens).toBe(8000);
+    } finally {
+      unlinkSync(path);
+    }
+  });
+});

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3,7 +3,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import TOML from 'toml';
-import type { AppConfig, ModelConfig, RuntimeConfig, AgentLoopConfig, EmbeddingConfig, DiscordConfig, InterfaceMode } from './types.ts';
+import type { AppConfig, ModelConfig, RuntimeConfig, AgentLoopConfig, EmbeddingConfig, DiscordConfig, InterfaceMode, SubModelConfig } from './types.ts';
 
 type RawConfig = {
   model?: Partial<ModelConfig> & Record<string, unknown>;
@@ -11,6 +11,7 @@ type RawConfig = {
   agent?: Partial<AgentLoopConfig> & Record<string, unknown>;
   embedding?: Partial<EmbeddingConfig> & Record<string, unknown>;
   discord?: Partial<DiscordConfig> & Record<string, unknown>;
+  sub_model?: Partial<SubModelConfig> & Record<string, unknown>;
   interface?: string;
 };
 
@@ -117,9 +118,26 @@ export function loadConfig(configPath: string): AppConfig {
       }
     : undefined;
 
+  // Sub-model config (optional — for cheaper LLM calls in compaction, titles, etc.)
+  const subModelProvider = process.env['SUB_MODEL_PROVIDER']
+    ?? pick(raw.sub_model, 'provider', undefined);
+
+  const subModel: SubModelConfig | undefined = subModelProvider
+    ? {
+        provider: subModelProvider as SubModelConfig['provider'],
+        name: process.env['SUB_MODEL_NAME']
+          ?? pick(raw.sub_model, 'name', 'claude-haiku-4-5-20251001'),
+        maxTokens: pick(raw.sub_model, 'maxTokens', 8000),
+        apiKey: process.env['SUB_MODEL_API_KEY']
+          ?? resolveApiKey(subModelProvider, pick(raw.sub_model, 'apiKey', undefined)),
+        baseUrl: process.env['SUB_MODEL_BASE_URL']
+          ?? resolveBaseUrl(subModelProvider, pick(raw.sub_model, 'baseUrl', undefined)),
+      }
+    : undefined;
+
   const rawInterface = raw.interface ?? 'tui';
   const interfaceMode: InterfaceMode =
     rawInterface === 'discord' || rawInterface === 'both' ? rawInterface : 'tui';
 
-  return { model, runtime, agent, embedding, discord, interface: interfaceMode };
+  return { model, runtime, agent, embedding, discord, interface: interfaceMode, subModel };
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -11,6 +11,14 @@ export type ModelConfig = {
   readonly reasoning?: ReasoningEffort;
 };
 
+export type SubModelConfig = {
+  readonly provider: 'anthropic' | 'openai-compat' | 'openrouter' | 'ollama' | 'lemonade';
+  readonly name: string;
+  readonly maxTokens: number;
+  readonly baseUrl?: string;
+  readonly apiKey?: string;
+};
+
 export type RuntimeConfig = {
   readonly workingDir: string;
   readonly dataDir?: string;  // protected directory — deny read/write in sandbox
@@ -53,4 +61,5 @@ export type AppConfig = {
   readonly embedding?: EmbeddingConfig;
   readonly discord?: DiscordConfig;
   readonly interface: InterfaceMode;
+  readonly subModel?: SubModelConfig;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@
 import { resolve } from 'path';
 import { loadConfig } from './config/loader.ts';
 import { createModelProvider } from './model/index.ts';
+import { createSubAgent, wrapMainModel } from './model/sub-agent.ts';
+import type { SubAgentLLM } from './model/sub-agent.ts';
 import { createDenoExecutor } from './runtime/executor.ts';
 import { createAgent } from './agent/agent.ts';
 import { createEmbeddingProvider } from './embedding/index.ts';
@@ -45,6 +47,12 @@ async function main(): Promise<void> {
 
   // Secret manager — flat JSON file for secret values (never in the DB)
   const secrets = createSecretManager(SECRETS_PATH);
+
+  // Sub-agent LLM — cheap model for compaction, titles, summarization.
+  // Falls back to wrapping the main model if [sub_model] not configured.
+  const subAgent: SubAgentLLM = config.subModel
+    ? createSubAgent(config.subModel)
+    : wrapMainModel(model, config.model.name, config.model.maxTokens);
 
   // Embedding + vector store (optional — gracefully degrades if Ollama is unavailable)
   let embedding: EmbeddingProvider | undefined;
@@ -91,6 +99,7 @@ async function main(): Promise<void> {
     get scheduler() { return scheduler; },
     store,
     secrets,
+    subAgent,
   };
   const sharedAgent = createAgent(agentDeps);
 

--- a/src/model/anthropic.ts
+++ b/src/model/anthropic.ts
@@ -20,7 +20,7 @@ function mapStopReason(reason: string | null): StopReason {
   }
 }
 
-function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
+function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock | null {
   if (block.type === 'text') {
     return { type: 'text', text: block.text };
   }
@@ -31,6 +31,9 @@ function mapContentBlock(block: Anthropic.ContentBlock): ContentBlock {
       name: block.name,
       input: block.input as Record<string, unknown>,
     };
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return null;
   }
   // Fallback: treat unknown block types as text
   return { type: 'text', text: String((block as unknown as Record<string, unknown>)['text'] ?? '') };
@@ -71,7 +74,16 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
         timeout: request.timeout ?? 120_000,
       });
 
-      const content: Array<ContentBlock> = response.content.map(mapContentBlock);
+      const content: Array<ContentBlock> = response.content
+        .map(mapContentBlock)
+        .filter((b): b is ContentBlock => b !== null);
+
+      const thinkingTexts = response.content
+        .filter((b): b is Anthropic.ThinkingBlock => b.type === 'thinking')
+        .map((b) => b.thinking);
+      const reasoning_content = thinkingTexts.length > 0
+        ? thinkingTexts.join('\n\n')
+        : undefined;
 
       return {
         content,
@@ -86,6 +98,7 @@ export function createAnthropicProvider(config: Readonly<ModelConfig>): ModelPro
             (response.usage as unknown as Record<string, unknown>)['cache_read_input_tokens'] as
               number | null | undefined ?? null,
         },
+        reasoning_content,
       };
     },
   };

--- a/src/model/ollama.ts
+++ b/src/model/ollama.ts
@@ -11,6 +11,7 @@ import type {
   StopReason,
   ToolDefinition,
 } from './types.ts';
+import { toolResultContentToString } from './types.ts';
 
 type OllamaMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -103,7 +104,7 @@ function convertMessages(
         } else if (block.type === 'tool_result') {
           result.push({
             role: 'tool',
-            content: block.content,
+            content: toolResultContentToString(block.content),
           });
         }
       }

--- a/src/model/openai-compat.ts
+++ b/src/model/openai-compat.ts
@@ -35,6 +35,7 @@ type OpenAIChoice = {
   message: {
     role: 'assistant';
     content: string | null;
+    reasoning_content?: string | null;
     tool_calls?: Array<{
       id: string;
       type: 'function';
@@ -271,6 +272,10 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
 
         const choice = data.choices[0]!;
 
+        const reasoning_content = typeof choice.message.reasoning_content === 'string' && choice.message.reasoning_content.length > 0
+          ? choice.message.reasoning_content
+          : undefined;
+
         return {
           content: mapResponseContent(choice),
           stop_reason: mapFinishReason(choice.finish_reason),
@@ -278,6 +283,7 @@ export function createOpenAICompatProvider(config: Readonly<ModelConfig>): Model
             input_tokens: data.usage.prompt_tokens,
             output_tokens: data.usage.completion_tokens,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/openai-compat.ts
+++ b/src/model/openai-compat.ts
@@ -10,6 +10,7 @@ import type {
   StopReason,
   ToolDefinition,
 } from './types.ts';
+import { toolResultContentToString } from './types.ts';
 
 type OpenAIMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -116,7 +117,7 @@ function convertMessages(
             toolResults.push({
               role: 'tool',
               tool_call_id: block.tool_use_id,
-              content: block.content,
+              content: toolResultContentToString(block.content),
             });
           }
         }
@@ -133,7 +134,7 @@ function convertMessages(
           result.push({
             role: 'tool',
             tool_call_id: block.tool_use_id,
-            content: block.content,
+            content: toolResultContentToString(block.content),
           });
         }
       }

--- a/src/model/openrouter.ts
+++ b/src/model/openrouter.ts
@@ -18,6 +18,7 @@ import type {
   StopReason,
   ToolDefinition,
 } from './types.ts';
+import { toolResultContentToString } from './types.ts';
 
 function convertMessages(
   messages: ReadonlyArray<Message>,
@@ -81,7 +82,7 @@ function convertMessages(
             result.push({
               role: 'tool',
               toolCallId: block.tool_use_id,
-              content: block.content,
+              content: toolResultContentToString(block.content),
             });
           }
         }
@@ -97,7 +98,7 @@ function convertMessages(
             result.push({
               role: 'tool',
               toolCallId: block.tool_use_id,
-              content: block.content,
+              content: toolResultContentToString(block.content),
             });
           }
         }

--- a/src/model/openrouter.ts
+++ b/src/model/openrouter.ts
@@ -227,6 +227,10 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
 
         process.stderr.write(`[openrouter] finish_reason=${choice.finishReason} tool_calls=${choice.message.toolCalls?.length ?? 0} content_len=${typeof choice.message.content === 'string' ? choice.message.content.length : 0}\n`);
 
+        const reasoning_content = typeof choice.message.reasoning === 'string' && choice.message.reasoning.length > 0
+          ? choice.message.reasoning
+          : undefined;
+
         return {
           content: mapResponseContent(choice.message),
           stop_reason: mapFinishReason(choice.finishReason),
@@ -234,6 +238,7 @@ export function createOpenRouterProvider(config: Readonly<ModelConfig>): ModelPr
             input_tokens: response.usage?.promptTokens ?? 0,
             output_tokens: response.usage?.completionTokens ?? 0,
           },
+          reasoning_content,
         };
       } finally {
         clearTimeout(timeoutId);

--- a/src/model/sub-agent.test.ts
+++ b/src/model/sub-agent.test.ts
@@ -1,0 +1,362 @@
+// pattern: Imperative Shell (test) — sub-agent providers, fallback wrapper
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createSubAgent, wrapMainModel } from './sub-agent.ts';
+import type { SubModelConfig } from '../config/types.ts';
+import type { ModelProvider, ModelRequest, ModelResponse } from './types.ts';
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+let originalFetch: typeof globalThis.fetch;
+let calls: FetchCall[];
+
+function installFetchMock(handler: (url: string, init?: RequestInit) => Response | Promise<Response>): void {
+  calls = [];
+  globalThis.fetch = (async (input: Parameters<typeof globalThis.fetch>[0], init?: RequestInit) => {
+    let url: string;
+    if (typeof input === 'string') url = input;
+    else if (input instanceof URL) url = input.toString();
+    else url = (input as Request).url;
+    calls.push({ url, init });
+    return handler(url, init);
+  }) as typeof globalThis.fetch;
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function readBody(init: RequestInit | undefined): Record<string, unknown> {
+  if (!init?.body) return {};
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('createSubAgent — anthropic', () => {
+  test('returns text from messages API response', async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        id: 'msg_1',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-haiku-4-5-20251001',
+        content: [{ type: 'text', text: 'summary text' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    );
+
+    const config: SubModelConfig = {
+      provider: 'anthropic',
+      name: 'claude-haiku-4-5-20251001',
+      maxTokens: 8000,
+      apiKey: 'test-key',
+    };
+    const subAgent = createSubAgent(config);
+    const result = await subAgent.complete('test prompt', 'test system');
+
+    expect(result).toBe('summary text');
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.url).toContain('/v1/messages');
+  });
+
+  test('joins multiple text blocks', async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        id: 'msg_2',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-haiku-4-5-20251001',
+        content: [
+          { type: 'text', text: 'hello ' },
+          { type: 'text', text: 'world' },
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 2 },
+      }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'anthropic',
+      name: 'claude-haiku-4-5-20251001',
+      maxTokens: 8000,
+      apiKey: 'test-key',
+    });
+
+    const result = await subAgent.complete('hi');
+    expect(result).toBe('hello world');
+  });
+});
+
+describe('createSubAgent — openai-compat', () => {
+  test('extracts choices[0].message.content from response', async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        choices: [{ message: { role: 'assistant', content: 'compat response' } }],
+      }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'openai-compat',
+      name: 'gpt-4o-mini',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:8080/v1',
+      apiKey: 'test-key',
+    });
+
+    const result = await subAgent.complete('hello');
+
+    expect(result).toBe('compat response');
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.url).toBe('http://localhost:8080/v1/chat/completions');
+    expect((calls[0]!.init as RequestInit).method).toBe('POST');
+
+    const body = readBody(calls[0]!.init);
+    expect(body['model']).toBe('gpt-4o-mini');
+    expect(body['max_tokens']).toBe(4000);
+    expect(body['messages']).toEqual([{ role: 'user', content: 'hello' }]);
+
+    const headers = (calls[0]!.init as RequestInit).headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-key');
+  });
+
+  test('includes system message when system param is provided', async () => {
+    installFetchMock(() =>
+      jsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'openai-compat',
+      name: 'gpt-4o-mini',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:8080/v1',
+      apiKey: 'k',
+    });
+
+    await subAgent.complete('user msg', 'system instruction');
+
+    const body = readBody(calls[0]!.init);
+    expect(body['messages']).toEqual([
+      { role: 'system', content: 'system instruction' },
+      { role: 'user', content: 'user msg' },
+    ]);
+  });
+
+  test('omits system message when system param is undefined', async () => {
+    installFetchMock(() =>
+      jsonResponse({ choices: [{ message: { content: 'ok' } }] }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'openai-compat',
+      name: 'gpt-4o-mini',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:8080/v1',
+      apiKey: 'k',
+    });
+
+    await subAgent.complete('only user');
+
+    const body = readBody(calls[0]!.init);
+    expect((body['messages'] as Array<unknown>).length).toBe(1);
+    expect(body['messages']).toEqual([{ role: 'user', content: 'only user' }]);
+  });
+
+  test('throws descriptive error on non-2xx response', async () => {
+    installFetchMock(() =>
+      new Response('upstream error body', { status: 500 }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'openai-compat',
+      name: 'gpt-4o-mini',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:8080/v1',
+      apiKey: 'k',
+    });
+
+    await expect(subAgent.complete('hi')).rejects.toThrow(/openai-compat/);
+  });
+});
+
+describe('createSubAgent — openrouter', () => {
+  test('uses OpenRouter base URL and extracts response', async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        choices: [{ message: { content: 'router response' } }],
+      }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'openrouter',
+      name: 'meta-llama/llama-3-8b',
+      maxTokens: 4000,
+      baseUrl: 'https://openrouter.ai/api/v1',
+      apiKey: 'or-key',
+    });
+
+    const result = await subAgent.complete('hi');
+
+    expect(result).toBe('router response');
+    expect(calls[0]!.url).toBe('https://openrouter.ai/api/v1/chat/completions');
+  });
+});
+
+describe('createSubAgent — ollama', () => {
+  test('extracts message.content from /api/chat response', async () => {
+    installFetchMock(() =>
+      jsonResponse({
+        message: { role: 'assistant', content: 'ollama response' },
+        done: true,
+      }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'ollama',
+      name: 'llama3',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:11434',
+    });
+
+    const result = await subAgent.complete('test');
+
+    expect(result).toBe('ollama response');
+    expect(calls[0]!.url).toBe('http://localhost:11434/api/chat');
+
+    const body = readBody(calls[0]!.init);
+    expect(body['model']).toBe('llama3');
+    expect(body['stream']).toBe(false);
+    const opts = body['options'] as Record<string, unknown>;
+    expect(opts['num_predict']).toBe(4000);
+  });
+
+  test('falls back to default localhost URL when baseUrl is not provided', async () => {
+    installFetchMock(() =>
+      jsonResponse({ message: { content: 'default url ok' } }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'ollama',
+      name: 'llama3',
+      maxTokens: 4000,
+    });
+
+    await subAgent.complete('hi');
+    expect(calls[0]!.url).toBe('http://localhost:11434/api/chat');
+  });
+});
+
+describe('createSubAgent — lemonade', () => {
+  test('uses OpenAI-compat endpoint pattern', async () => {
+    installFetchMock(() =>
+      jsonResponse({ choices: [{ message: { content: 'lemonade' } }] }),
+    );
+
+    const subAgent = createSubAgent({
+      provider: 'lemonade',
+      name: 'local-model',
+      maxTokens: 4000,
+      baseUrl: 'http://localhost:13305/api/v1',
+      apiKey: 'lemonade',
+    });
+
+    const result = await subAgent.complete('test');
+
+    expect(result).toBe('lemonade');
+    expect(calls[0]!.url).toBe('http://localhost:13305/api/v1/chat/completions');
+  });
+});
+
+describe('wrapMainModel', () => {
+  function makeMockModel(response: ModelResponse): { model: ModelProvider; received: ModelRequest[] } {
+    const received: ModelRequest[] = [];
+    const model: ModelProvider = {
+      async complete(req: Readonly<ModelRequest>) {
+        received.push(req as ModelRequest);
+        return response;
+      },
+    };
+    return { model, received };
+  }
+
+  test('extracts text from content blocks and joins them', async () => {
+    const { model } = makeMockModel({
+      content: [
+        { type: 'text', text: 'hello' },
+        { type: 'text', text: ' world' },
+      ],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+
+    const subAgent = wrapMainModel(model, 'test-model', 16000);
+    const result = await subAgent.complete('prompt');
+
+    expect(result).toBe('hello world');
+  });
+
+  test('passes tools: [] to the underlying model', async () => {
+    const { model, received } = makeMockModel({
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const subAgent = wrapMainModel(model, 'test-model', 16000);
+    await subAgent.complete('prompt');
+
+    expect(received[0]!.tools).toEqual([]);
+  });
+
+  test('caps max_tokens at 8000 even when called with a larger maxTokens', async () => {
+    const { model, received } = makeMockModel({
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const subAgent = wrapMainModel(model, 'test-model', 16384);
+    await subAgent.complete('prompt');
+
+    expect(received[0]!.max_tokens).toBe(8000);
+  });
+
+  test('respects smaller maxTokens caller value', async () => {
+    const { model, received } = makeMockModel({
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const subAgent = wrapMainModel(model, 'test-model', 4096);
+    await subAgent.complete('prompt');
+
+    expect(received[0]!.max_tokens).toBe(4096);
+  });
+
+  test('forwards the system prompt to the underlying model', async () => {
+    const { model, received } = makeMockModel({
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+
+    const subAgent = wrapMainModel(model, 'test-model', 4096);
+    await subAgent.complete('prompt', 'be helpful');
+
+    expect(received[0]!.system).toBe('be helpful');
+  });
+});

--- a/src/model/sub-agent.ts
+++ b/src/model/sub-agent.ts
@@ -1,0 +1,189 @@
+// pattern: Imperative Shell — minimal LLM client for tool-side single-shot calls
+
+import Anthropic from '@anthropic-ai/sdk';
+import type { SubModelConfig } from '../config/types.ts';
+import type { ModelProvider } from './types.ts';
+
+export type SubAgentLLM = {
+  complete(prompt: string, system?: string): Promise<string>;
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+type ChatMessage = { role: 'system' | 'user'; content: string };
+
+function buildMessages(prompt: string, system?: string): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  if (system) msgs.push({ role: 'system', content: system });
+  msgs.push({ role: 'user', content: prompt });
+  return msgs;
+}
+
+async function completeViaOpenAI(
+  baseUrl: string,
+  apiKey: string | undefined,
+  model: string,
+  maxTokens: number,
+  prompt: string,
+  system: string | undefined,
+): Promise<string> {
+  const endpoint = baseUrl.replace(/\/+$/, '') + '/chat/completions';
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+  const body = {
+    model,
+    max_tokens: maxTokens,
+    messages: buildMessages(prompt, system),
+  };
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errBody = await res.text();
+      throw new Error(`HTTP ${res.status}: ${errBody.slice(0, 500)}`);
+    }
+
+    const json = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string | null } }>;
+    };
+    const content = json.choices?.[0]?.message?.content;
+    return typeof content === 'string' ? content : '';
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function completeViaOllama(
+  baseUrl: string,
+  model: string,
+  maxTokens: number,
+  prompt: string,
+  system: string | undefined,
+): Promise<string> {
+  const endpoint = baseUrl.replace(/\/+$/, '') + '/api/chat';
+
+  const body = {
+    model,
+    messages: buildMessages(prompt, system),
+    stream: false,
+    options: { num_predict: maxTokens },
+  };
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const errBody = await res.text();
+      throw new Error(`HTTP ${res.status}: ${errBody.slice(0, 500)}`);
+    }
+
+    const json = (await res.json()) as { message?: { content?: string | null } };
+    const content = json.message?.content;
+    return typeof content === 'string' ? content : '';
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function completeViaAnthropic(
+  apiKey: string | undefined,
+  model: string,
+  maxTokens: number,
+  prompt: string,
+  system: string | undefined,
+): Promise<string> {
+  const client = new Anthropic({
+    apiKey,
+    fetch: (url, init) => globalThis.fetch(url as Parameters<typeof globalThis.fetch>[0], init as RequestInit),
+  });
+
+  const params: Anthropic.MessageCreateParamsNonStreaming = {
+    model,
+    max_tokens: maxTokens,
+    messages: [{ role: 'user', content: prompt }],
+  };
+  if (system) params.system = system;
+
+  const response = await client.messages.create(params);
+
+  return response.content
+    .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+    .map((b) => b.text)
+    .join('');
+}
+
+export function createSubAgent(config: Readonly<SubModelConfig>): SubAgentLLM {
+  const { provider, name, maxTokens, baseUrl, apiKey } = config;
+
+  return {
+    async complete(prompt: string, system?: string): Promise<string> {
+      try {
+        if (provider === 'anthropic') {
+          return await completeViaAnthropic(apiKey, name, maxTokens, prompt, system);
+        }
+
+        if (provider === 'ollama') {
+          const url = baseUrl ?? 'http://localhost:11434';
+          return await completeViaOllama(url, name, maxTokens, prompt, system);
+        }
+
+        if (provider === 'openai-compat' || provider === 'openrouter' || provider === 'lemonade') {
+          if (!baseUrl) {
+            throw new Error(`Sub-agent provider "${provider}" requires baseUrl`);
+          }
+          return await completeViaOpenAI(baseUrl, apiKey, name, maxTokens, prompt, system);
+        }
+
+        throw new Error(`Unknown sub-agent provider: ${provider}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Sub-agent (${provider}) call failed: ${message}`);
+      }
+    },
+  };
+}
+
+/**
+ * Fallback: wrap a `ModelProvider` so it satisfies the `SubAgentLLM` interface.
+ * Used when no `[sub_model]` is configured — the main model handles utility calls.
+ * Caps `max_tokens` at 8000 to keep these calls cheap.
+ */
+export function wrapMainModel(
+  model: ModelProvider,
+  modelName: string,
+  maxTokens: number,
+): SubAgentLLM {
+  return {
+    async complete(prompt: string, system?: string): Promise<string> {
+      const response = await model.complete({
+        messages: [{ role: 'user', content: prompt }],
+        system,
+        tools: [],
+        model: modelName,
+        max_tokens: Math.min(maxTokens, 8000),
+      });
+      return response.content
+        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+        .map((b) => b.text)
+        .join('');
+    },
+  };
+}

--- a/src/model/types.test.ts
+++ b/src/model/types.test.ts
@@ -1,0 +1,40 @@
+// pattern: Functional Core (test) — exercises pure helpers from types.ts
+
+import { describe, expect, it } from 'bun:test';
+import { toolResultContentToString } from './types.ts';
+import type { ToolResultContentBlock } from './types.ts';
+
+describe('toolResultContentToString', () => {
+  it('GH03.AC7.1 (string path): returns string content as-is', () => {
+    expect(toolResultContentToString('hello world')).toBe('hello world');
+    expect(toolResultContentToString('')).toBe('');
+  });
+
+  it('GH03.AC7.1 (array with text): joins text blocks with newlines', () => {
+    const content: ToolResultContentBlock[] = [
+      { type: 'text', text: 'line one' },
+      { type: 'text', text: 'line two' },
+    ];
+    expect(toolResultContentToString(content)).toBe('line one\nline two');
+  });
+
+  it('GH03.AC7.1 (array with image): renders image as [image] placeholder', () => {
+    const content: ToolResultContentBlock[] = [
+      { type: 'image_url', image_url: { url: 'https://example.com/x.png' } },
+    ];
+    expect(toolResultContentToString(content)).toBe('[image]');
+  });
+
+  it('GH03.AC7.1 (mixed array): joins text and [image] placeholder with newlines', () => {
+    const content: ToolResultContentBlock[] = [
+      { type: 'text', text: 'before' },
+      { type: 'image_url', image_url: { url: 'https://example.com/x.png' } },
+      { type: 'text', text: 'after' },
+    ];
+    expect(toolResultContentToString(content)).toBe('before\n[image]\nafter');
+  });
+
+  it('GH03.AC7.1 (empty array): returns empty string', () => {
+    expect(toolResultContentToString([])).toBe('');
+  });
+});

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -35,6 +35,7 @@ export type ToolDefinition = {
 export type Message = {
   role: 'user' | 'assistant';
   content: string | Array<ContentBlock>;
+  reasoning_content?: string;
 };
 
 export type ModelRequest = {
@@ -60,6 +61,7 @@ export type ModelResponse = {
   content: Array<ContentBlock>;
   stop_reason: StopReason;
   usage: UsageStats;
+  reasoning_content?: string;
 };
 
 export type ModelProvider = {

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -12,16 +12,18 @@ export type ToolUseBlock = {
   input: Record<string, unknown>;
 };
 
-export type ToolResultBlock = {
-  type: 'tool_result';
-  tool_use_id: string;
-  content: string;
-  is_error?: boolean;
-};
-
 export type ImageBlock = {
   type: 'image_url';
   image_url: { url: string };
+};
+
+export type ToolResultContentBlock = TextBlock | ImageBlock;
+
+export type ToolResultBlock = {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string | Array<ToolResultContentBlock>;
+  is_error?: boolean;
 };
 
 export type ContentBlock = TextBlock | ImageBlock | ToolUseBlock | ToolResultBlock;
@@ -67,3 +69,23 @@ export type ModelResponse = {
 export type ModelProvider = {
   complete(request: Readonly<ModelRequest>): Promise<ModelResponse>;
 };
+
+/**
+ * Serialize ToolResultBlock content to a plain string.
+ * If content is already a string, return as-is.
+ * If content is an array of content blocks, extract text parts and join them.
+ * Image blocks are represented as '[image]' placeholders.
+ */
+export function toolResultContentToString(
+  content: string | Array<ToolResultContentBlock>,
+): string {
+  if (typeof content === 'string') return content;
+  return content
+    .map((block) => {
+      if (block.type === 'text') return block.text;
+      if (block.type === 'image_url') return '[image]';
+      return '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}

--- a/src/runtime/deno/tools.ts
+++ b/src/runtime/deno/tools.ts
@@ -40,3 +40,8 @@ export async function list_tasks(params: Record<string, unknown>): Promise<unkno
 export async function cancel_task(params: { id: string }): Promise<unknown> {
   return callTool("cancel_task", params);
 }
+
+/** Summarize text using a sub-agent LLM. Returns a concise summary preserving key facts. */
+export async function summarize(params: { text: string; instructions?: string; max_length?: "short" | "medium" | "long" }): Promise<unknown> {
+  return callTool("summarize", params);
+}

--- a/src/runtime/tool-registry.test.ts
+++ b/src/runtime/tool-registry.test.ts
@@ -1,0 +1,100 @@
+// pattern: Imperative Shell (test) — exercises registry with synthetic tools
+
+import { describe, expect, it } from 'bun:test';
+import { createToolRegistry } from './tool-registry.ts';
+import type { ToolDefinition } from '../model/types.ts';
+import type { ToolHandler } from './tool-registry.ts';
+
+function makeDefinition(name: string): ToolDefinition {
+  return {
+    name,
+    description: `Description for ${name}`,
+    input_schema: {
+      type: 'object',
+      properties: {
+        arg: { type: 'string', description: 'an argument' },
+      },
+      required: ['arg'],
+    },
+  };
+}
+
+const noopHandler: ToolHandler = async () => null;
+
+describe('ToolRegistry mode filtering', () => {
+  it('GH03.AC1.1: stores tools registered with each mode value', () => {
+    const reg = createToolRegistry();
+    reg.register('sand_tool', makeDefinition('sand_tool'), noopHandler, 'sandbox');
+    reg.register('nat_tool', makeDefinition('nat_tool'), noopHandler, 'native');
+    reg.register('both_tool', makeDefinition('both_tool'), noopHandler, 'both');
+
+    expect(reg.get('sand_tool')).toBeDefined();
+    expect(reg.get('nat_tool')).toBeDefined();
+    expect(reg.get('both_tool')).toBeDefined();
+  });
+
+  it('GH03.AC1.2: generateToolDefinitions returns only native and both-mode tools', () => {
+    const reg = createToolRegistry();
+    reg.register('sand_tool', makeDefinition('sand_tool'), noopHandler, 'sandbox');
+    reg.register('nat_tool', makeDefinition('nat_tool'), noopHandler, 'native');
+    reg.register('both_tool', makeDefinition('both_tool'), noopHandler, 'both');
+
+    const defs = reg.generateToolDefinitions();
+    const names = defs.map((d) => d.name);
+
+    expect(names).toContain('nat_tool');
+    expect(names).toContain('both_tool');
+    expect(names).not.toContain('sand_tool');
+    expect(defs.length).toBe(2);
+  });
+
+  it('GH03.AC1.3: generateTypeScriptStubs emits stubs only for sandbox and both-mode tools', () => {
+    const reg = createToolRegistry();
+    reg.register('sand_tool', makeDefinition('sand_tool'), noopHandler, 'sandbox');
+    reg.register('nat_tool', makeDefinition('nat_tool'), noopHandler, 'native');
+    reg.register('both_tool', makeDefinition('both_tool'), noopHandler, 'both');
+
+    const stubs = reg.generateTypeScriptStubs();
+
+    expect(stubs).toContain('export async function sand_tool');
+    expect(stubs).toContain('export async function both_tool');
+    expect(stubs).not.toContain('export async function nat_tool');
+  });
+
+  it('GH03.AC1.4: generateToolDocumentation documents all tools regardless of mode', () => {
+    const reg = createToolRegistry();
+    reg.register('sand_tool', makeDefinition('sand_tool'), noopHandler, 'sandbox');
+    reg.register('nat_tool', makeDefinition('nat_tool'), noopHandler, 'native');
+    reg.register('both_tool', makeDefinition('both_tool'), noopHandler, 'both');
+
+    const docs = reg.generateToolDocumentation();
+
+    expect(docs).toContain('tools.sand_tool');
+    expect(docs).toContain('tools.nat_tool');
+    expect(docs).toContain('tools.both_tool');
+  });
+
+  it('GH03.AC1.5: register() without mode defaults to sandbox', () => {
+    const reg = createToolRegistry();
+    reg.register('default_tool', makeDefinition('default_tool'), noopHandler);
+
+    const stubs = reg.generateTypeScriptStubs();
+    const docs = reg.generateToolDocumentation();
+    const defs = reg.generateToolDefinitions();
+
+    expect(stubs).toContain('export async function default_tool');
+    expect(docs).toContain('tools.default_tool');
+    expect(defs.map((d) => d.name)).not.toContain('default_tool');
+  });
+
+  it('GH03.AC9.1: native tool appears in definitions but not in stubs', () => {
+    const reg = createToolRegistry();
+    reg.register('only_native', makeDefinition('only_native'), noopHandler, 'native');
+
+    const defs = reg.generateToolDefinitions();
+    const stubs = reg.generateTypeScriptStubs();
+
+    expect(defs.map((d) => d.name)).toContain('only_native');
+    expect(stubs).not.toContain('export async function only_native');
+  });
+});

--- a/src/runtime/tool-registry.test.ts
+++ b/src/runtime/tool-registry.test.ts
@@ -69,9 +69,13 @@ describe('ToolRegistry mode filtering', () => {
 
     const docs = reg.generateToolDocumentation();
 
+    expect(docs).toContain('sand_tool');
+    expect(docs).toContain('nat_tool');
+    expect(docs).toContain('both_tool');
     expect(docs).toContain('tools.sand_tool');
-    expect(docs).toContain('tools.nat_tool');
-    expect(docs).toContain('tools.both_tool');
+    expect(docs).toContain('Description for sand_tool');
+    expect(docs).toContain('Description for nat_tool');
+    expect(docs).toContain('Description for both_tool');
   });
 
   it('GH03.AC1.5: register() without mode defaults to sandbox', () => {

--- a/src/runtime/tool-registry.ts
+++ b/src/runtime/tool-registry.ts
@@ -12,9 +12,12 @@ export type ToolHandler = (
   params: Record<string, unknown>,
 ) => Promise<unknown>;
 
+export type ToolMode = 'sandbox' | 'native' | 'both';
+
 type RegistryEntry = {
   definition: ToolDefinition;
   handler: ToolHandler;
+  mode: ToolMode;
 };
 
 export type ToolRegistry = {
@@ -22,12 +25,14 @@ export type ToolRegistry = {
     name: string,
     definition: ToolDefinition,
     handler: ToolHandler,
+    mode?: ToolMode,
   ): void;
   get(
     name: string,
   ): { definition: ToolDefinition; handler: ToolHandler } | undefined;
   list(): Array<{ name: string; definition: ToolDefinition }>;
   execute(name: string, params: Record<string, unknown>): Promise<unknown>;
+  generateToolDefinitions(): ToolDefinition[];
   generateTypeScriptStubs(): string;
   generateToolDocumentation(): string;
 };
@@ -117,8 +122,19 @@ export function createToolRegistry(): ToolRegistry {
     name: string,
     definition: ToolDefinition,
     handler: ToolHandler,
+    mode: ToolMode = 'sandbox',
   ): void {
-    entries.set(name, { definition, handler });
+    entries.set(name, { definition, handler, mode });
+  }
+
+  function generateToolDefinitions(): ToolDefinition[] {
+    const definitions: ToolDefinition[] = [];
+    for (const [, entry] of entries) {
+      if (entry.mode === 'native' || entry.mode === 'both') {
+        definitions.push(entry.definition);
+      }
+    }
+    return definitions;
   }
 
   function get(
@@ -159,6 +175,7 @@ export function createToolRegistry(): ToolRegistry {
     ];
 
     for (const [name, entry] of entries) {
+      if (entry.mode === 'native') continue;
       const paramsType = buildParamsType(entry.definition.input_schema);
       // Escape */ in descriptions to avoid prematurely closing JSDoc comments
       const safeDesc = (entry.definition.description ?? '').split('\n')[0]!.replace(/\*\//g, '*\\/');
@@ -213,6 +230,7 @@ export function createToolRegistry(): ToolRegistry {
     get,
     list,
     execute,
+    generateToolDefinitions,
     generateTypeScriptStubs,
     generateToolDocumentation,
   };

--- a/src/runtime/tool-registry.ts
+++ b/src/runtime/tool-registry.ts
@@ -200,8 +200,21 @@ export function createToolRegistry(): ToolRegistry {
 
     for (const [name, entry] of entries) {
       const def = entry.definition;
-      sections.push(`### \`tools.${name}\``);
-      sections.push("");
+
+      if (entry.mode === 'native' || entry.mode === 'both') {
+        sections.push(`### \`${name}\` *(direct tool call)*`);
+        sections.push("");
+        if (entry.mode === 'both') {
+          sections.push(`> Available as both a direct tool call and via \`tools.${name}()\` in execute_code.`);
+        } else {
+          sections.push(`> Call this tool directly — do NOT use execute_code for this tool.`);
+        }
+        sections.push("");
+      } else {
+        sections.push(`### \`tools.${name}\``);
+        sections.push("");
+      }
+
       sections.push(def.description);
       sections.push("");
 

--- a/src/secrets/manager.test.ts
+++ b/src/secrets/manager.test.ts
@@ -1,0 +1,130 @@
+// Integration tests for SecretManager — verifies persistence lifecycle against real filesystem.
+
+import { readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSecretManager } from './manager.ts';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+
+const TEST_DIR = join(import.meta.dir, '../../.test-tmp');
+const TEST_PATH = join(TEST_DIR, 'secrets.json');
+
+function cleanup(): void {
+  try {
+    rmSync(TEST_DIR, { recursive: true });
+  } catch {
+    // ignore if doesn't exist
+  }
+}
+
+describe('SecretManager', () => {
+  beforeEach(cleanup);
+  afterEach(cleanup);
+
+  test('set() persists to JSON file on disk', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ FOO: 'bar' });
+  });
+
+  test('set() returns a Promise', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const result = mgr.set('X', 'Y');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('remove() returns a Promise', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('X', 'Y');
+    const result = mgr.remove('X');
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  test('get() retrieves a previously set value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('TOKEN', 'abc123');
+    expect(mgr.get('TOKEN')).toBe('abc123');
+  });
+
+  test('get() returns undefined for missing keys', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    expect(mgr.get('NONEXISTENT')).toBeUndefined();
+  });
+
+  test('remove() deletes a secret and persists', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('DEL_ME', 'gone');
+    await mgr.remove('DEL_ME');
+
+    expect(mgr.get('DEL_ME')).toBeUndefined();
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({});
+  });
+
+  test('listKeys() returns sorted key names', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('ZEBRA', 'z');
+    await mgr.set('ALPHA', 'a');
+    await mgr.set('MIDDLE', 'm');
+
+    expect(mgr.listKeys()).toEqual(['ALPHA', 'MIDDLE', 'ZEBRA']);
+  });
+
+  test('resolve() returns env map for existing keys, skips missing', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('FOO', 'bar');
+    await mgr.set('BAZ', 'qux');
+
+    const env = mgr.resolve(['FOO', 'MISSING', 'BAZ']);
+    expect(env).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  test('resolve() returns empty object when no keys match', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    const env = mgr.resolve(['NOTHING', 'NOPE']);
+    expect(env).toEqual({});
+  });
+
+  test('new manager loads persisted secrets from disk', async () => {
+    const mgr1 = createSecretManager(TEST_PATH);
+    await mgr1.set('PERSIST', 'across-instances');
+
+    const mgr2 = createSecretManager(TEST_PATH);
+    expect(mgr2.get('PERSIST')).toBe('across-instances');
+    expect(mgr2.listKeys()).toEqual(['PERSIST']);
+  });
+
+  test('set() overwrites existing value', async () => {
+    const mgr = createSecretManager(TEST_PATH);
+    await mgr.set('KEY', 'old');
+    await mgr.set('KEY', 'new');
+
+    expect(mgr.get('KEY')).toBe('new');
+
+    const raw = readFileSync(TEST_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ KEY: 'new' });
+  });
+
+  test('creates parent directory if it does not exist', async () => {
+    const nested = join(TEST_DIR, 'deep', 'nested', 'secrets.json');
+    const mgr = createSecretManager(nested);
+    await mgr.set('DEEP', 'value');
+
+    const raw = readFileSync(nested, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ DEEP: 'value' });
+  });
+
+  test('ignoring returned promise does not throw (backward compat)', () => {
+    const mgr = createSecretManager(TEST_PATH);
+    // Existing callers call set()/remove() without await — this must not throw
+    mgr.set('IGNORED', 'promise');
+    mgr.remove('IGNORED');
+    // If we get here without error, backward compat is satisfied
+  });
+});

--- a/src/secrets/manager.test.ts
+++ b/src/secrets/manager.test.ts
@@ -40,6 +40,7 @@ describe('SecretManager', () => {
     await mgr.set('X', 'Y');
     const result = mgr.remove('X');
     expect(result).toBeInstanceOf(Promise);
+    await result;
   });
 
   test('get() retrieves a previously set value', async () => {
@@ -120,11 +121,12 @@ describe('SecretManager', () => {
     expect(data).toEqual({ DEEP: 'value' });
   });
 
-  test('ignoring returned promise does not throw (backward compat)', () => {
+  test('ignoring returned promise does not throw (backward compat)', async () => {
     const mgr = createSecretManager(TEST_PATH);
-    // Existing callers call set()/remove() without await — this must not throw
-    mgr.set('IGNORED', 'promise');
-    mgr.remove('IGNORED');
-    // If we get here without error, backward compat is satisfied
+    // Existing callers call set()/remove() without await — this must not throw synchronously
+    const p1 = mgr.set('IGNORED', 'promise');
+    const p2 = mgr.remove('IGNORED');
+    await p1;
+    await p2;
   });
 });

--- a/src/secrets/manager.ts
+++ b/src/secrets/manager.ts
@@ -13,10 +13,10 @@ export type SecretManager = {
   listKeys(): Array<string>;
   /** Get a secret value. Internal only — for env injection. */
   get(key: string): string | undefined;
-  /** Set a secret. */
-  set(key: string, value: string): void;
-  /** Delete a secret. */
-  remove(key: string): void;
+  /** Set a secret. Resolves when persisted to disk. */
+  set(key: string, value: string): Promise<void>;
+  /** Delete a secret. Resolves when persisted to disk. */
+  remove(key: string): Promise<void>;
   /** Resolve secrets for a skill → env var map. Takes an array of key names. */
   resolve(keys: ReadonlyArray<string>): Record<string, string>;
 };
@@ -37,10 +37,9 @@ export function createSecretManager(path: string): SecretManager {
     // File doesn't exist yet — start fresh
   }
 
-  function save(): void {
-    mkdir(dirname(path), { recursive: true })
-      .then(() => writeFile(path, JSON.stringify(secrets, null, 2) + '\n'))
-      .catch(() => {});
+  async function save(): Promise<void> {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(secrets, null, 2) + '\n');
   }
 
   return {
@@ -52,14 +51,14 @@ export function createSecretManager(path: string): SecretManager {
       return secrets[key];
     },
 
-    set(key: string, value: string): void {
+    async set(key: string, value: string): Promise<void> {
       secrets[key] = value;
-      save();
+      await save();
     },
 
-    remove(key: string): void {
+    async remove(key: string): Promise<void> {
       delete secrets[key];
-      save();
+      await save();
     },
 
     resolve(keys: ReadonlyArray<string>): Record<string, string> {

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -1,0 +1,12 @@
+// pattern: Functional Core — shared parameter extraction helpers for tool handlers
+
+export function str(input: Record<string, unknown>, key: string): string {
+  const val = input[key];
+  if (typeof val !== 'string') throw new Error(`missing required param: ${key}`);
+  return val;
+}
+
+export function optStr(input: Record<string, unknown>, key: string, fallback: string = ''): string {
+  const val = input[key];
+  return typeof val === 'string' ? val : fallback;
+}

--- a/src/tools/summarize.test.ts
+++ b/src/tools/summarize.test.ts
@@ -1,0 +1,137 @@
+// pattern: Imperative Shell (test) — exercises summarize tool against a mock SubAgentLLM
+
+import { describe, expect, test } from 'bun:test';
+import { createToolRegistry } from '../runtime/tool-registry.ts';
+import { registerSummarizeTools } from './summarize.ts';
+import type { AgentDependencies } from '../agent/types.ts';
+
+type Captured = {
+  prompt: string;
+  system: string;
+  callCount: number;
+};
+
+function makeMockSubAgent(returnValue: string = 'Mock summary result.') {
+  const captured: Captured = { prompt: '', system: '', callCount: 0 };
+  const subAgent = {
+    async complete(prompt: string, system?: string): Promise<string> {
+      captured.prompt = prompt;
+      captured.system = system ?? '';
+      captured.callCount += 1;
+      return returnValue;
+    },
+  };
+  return { captured, subAgent };
+}
+
+function setupRegistry(subAgent?: { complete(prompt: string, system?: string): Promise<string> }) {
+  const registry = createToolRegistry();
+  const deps = { subAgent } as unknown as AgentDependencies;
+  registerSummarizeTools(registry, deps);
+  return registry;
+}
+
+describe('summarize tool', () => {
+  test('GH08.AC1.1: sends text to sub-agent with summarization system prompt', async () => {
+    const { captured, subAgent } = makeMockSubAgent('A short summary.');
+    const registry = setupRegistry(subAgent);
+
+    const result = await registry.execute('summarize', { text: 'Some content to summarize' });
+
+    expect(captured.callCount).toBe(1);
+    expect(captured.system).toBe(
+      'You are a precise summarization assistant. Preserve key facts, names, and numbers. Do not add information not present in the source text.',
+    );
+    expect(captured.prompt).toContain('Some content to summarize');
+    expect(result).toEqual({ summary: 'A short summary.' });
+  });
+
+  test('GH08.AC2.1: input is truncated at 100k chars', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    const oversized = 'x'.repeat(200_000);
+    await registry.execute('summarize', { text: oversized });
+
+    expect(captured.prompt.length).toBeLessThan(100_200);
+    expect(captured.prompt).toContain('x'.repeat(100_000));
+    expect(captured.prompt).not.toContain('x'.repeat(100_001));
+  });
+
+  test('GH08.AC3.1: max_length="short" maps to 2-3 sentence guidance', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', { text: 'test', max_length: 'short' });
+
+    expect(captured.prompt).toContain('Respond in 2-3 sentences.');
+  });
+
+  test('GH08.AC3.1: max_length="medium" maps to 1-2 paragraph guidance', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', { text: 'test', max_length: 'medium' });
+
+    expect(captured.prompt).toContain('Respond in 1-2 paragraphs.');
+  });
+
+  test('GH08.AC3.1: max_length="long" maps to 4-paragraph guidance', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', { text: 'test', max_length: 'long' });
+
+    expect(captured.prompt).toContain('Respond in up to 4 paragraphs.');
+  });
+
+  test('GH08.AC3.1: missing max_length defaults to medium guidance', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', { text: 'test' });
+
+    expect(captured.prompt).toContain('Respond in 1-2 paragraphs.');
+  });
+
+  test('GH08.AC4.1: instructions are appended as Focus guidance', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', {
+      text: 'test',
+      instructions: 'focus on technical claims',
+    });
+
+    expect(captured.prompt).toContain('Focus: focus on technical claims');
+  });
+
+  test('GH08.AC4.1: no instructions means no Focus line in prompt', async () => {
+    const { captured, subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    await registry.execute('summarize', { text: 'test' });
+
+    expect(captured.prompt).not.toContain('Focus:');
+  });
+
+  test('GH08.AC5.1: missing sub-agent throws a clear error', async () => {
+    const registry = setupRegistry(undefined);
+
+    await expect(registry.execute('summarize', { text: 'test' })).rejects.toThrow(
+      /Sub-agent LLM not configured/,
+    );
+  });
+
+  test('GH08.AC6.1: tool is registered with mode "both" so it appears in both native and sandbox surfaces', async () => {
+    const { subAgent } = makeMockSubAgent();
+    const registry = setupRegistry(subAgent);
+
+    const nativeDefs = registry.generateToolDefinitions();
+    const summarizeNative = nativeDefs.find((d) => d.name === 'summarize');
+    expect(summarizeNative).toBeDefined();
+
+    const sandboxStubs = registry.generateTypeScriptStubs();
+    expect(sandboxStubs).toContain('summarize');
+  });
+});

--- a/src/tools/summarize.ts
+++ b/src/tools/summarize.ts
@@ -1,0 +1,70 @@
+// pattern: Functional Core — summarize tool registration
+
+import type { ToolRegistry } from '../runtime/tool-registry.ts';
+import type { AgentDependencies } from '../agent/types.ts';
+import { str, optStr } from './helpers.ts';
+
+const LENGTH_GUIDANCE: Record<string, string> = {
+  short: 'Respond in 2-3 sentences.',
+  medium: 'Respond in 1-2 paragraphs.',
+  long: 'Respond in up to 4 paragraphs.',
+};
+
+const SUMMARIZE_SYSTEM =
+  'You are a precise summarization assistant. Preserve key facts, names, and numbers. Do not add information not present in the source text.';
+
+const MAX_INPUT_CHARS = 100_000;
+
+export function registerSummarizeTools(
+  registry: ToolRegistry,
+  deps: Readonly<AgentDependencies>,
+): void {
+  registry.register(
+    'summarize',
+    {
+      name: 'summarize',
+      description:
+        'Summarize text using a sub-agent LLM. Returns a concise summary preserving key facts.\n\n' +
+        'Use for long documents, articles, or any content that needs condensing. Optionally provide focus instructions to guide what the summary emphasizes.',
+      input_schema: {
+        type: 'object',
+        properties: {
+          text: {
+            type: 'string',
+            description: 'Content to summarize (truncated at 100k chars)',
+          },
+          instructions: {
+            type: 'string',
+            description: 'Optional focus guidance (e.g., "focus on technical claims")',
+          },
+          max_length: {
+            type: 'string',
+            enum: ['short', 'medium', 'long'],
+            description:
+              'Summary length: "short" (2-3 sentences), "medium" (1-2 paragraphs), "long" (up to 4 paragraphs). Default: "medium".',
+          },
+        },
+        required: ['text'],
+      },
+    },
+    async (params) => {
+      if (!deps.subAgent) {
+        throw new Error('Sub-agent LLM not configured. Add [sub_model] to config.toml.');
+      }
+
+      const text = str(params, 'text').slice(0, MAX_INPUT_CHARS);
+      const instructions = optStr(params, 'instructions');
+      const maxLength = optStr(params, 'max_length', 'medium');
+
+      let prompt = `Summarize the following text. ${LENGTH_GUIDANCE[maxLength] ?? LENGTH_GUIDANCE.medium}`;
+      if (instructions) {
+        prompt += `\n\nFocus: ${instructions}`;
+      }
+      prompt += `\n\n---\n\n${text}`;
+
+      const result = await deps.subAgent.complete(prompt, SUMMARIZE_SYSTEM);
+      return { summary: result };
+    },
+    'both',
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a `summarize` native+sandbox tool that condenses text via the sub-agent LLM with configurable length (short/medium/long), optional focus `instructions`, and 100k char input truncation.
- Extracts `str` / `optStr` parameter helpers from `src/agent/tools.ts` into a new shared `src/tools/helpers.ts`, ready to be reused by future tool modules.
- Registers `summarize` with `mode: 'both'` so it is exposed as a native tool definition and as a sandbox stub.

## Files
- `src/tools/summarize.ts` — registration + handler
- `src/tools/helpers.ts` — shared parameter extraction
- `src/tools/summarize.test.ts` — 10 tests covering GH08.AC1.1-AC6.1
- `src/agent/tools.ts` — wires `registerSummarizeTools` into `createAgentTools`
- `src/agent/agent.test.ts` — GH01.AC4.1 now asserts a symbolic tool count rather than hardcoded `1` (the agent's tool surface gained a second tool)

## Test plan
- [x] `bun run build` succeeds
- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 75 pass / 0 fail (10 new summarize tests)
- [x] Verified prerequisites: `SubAgentLLM` from GH04, `mode: 'both'` 4-arg `register()` from GH03

🤖 Generated with [Claude Code](https://claude.com/claude-code)